### PR TITLE
fix(cli): exit non-zero when a command fails

### DIFF
--- a/src/venice_ai/cli/commands/chat.py
+++ b/src/venice_ai/cli/commands/chat.py
@@ -492,7 +492,7 @@ async def _chat_async(
                 model = await _select_chat_model(client)
                 if not model:
                     print_error("No model selected. Exiting.")
-                    return
+                    raise SystemExit(1)
                 model_was_explicit = True
                 print_success(f"Selected model: {model}")
             else:
@@ -611,8 +611,10 @@ async def _chat_async(
 
     except VeniceError as e:
         print_error(f"Venice API error: {e}")
+        raise SystemExit(1) from e
     except Exception as e:
         print_error(f"Unexpected error: {e}")
+        raise SystemExit(1) from e
 
 
 async def _send_single_message(

--- a/src/venice_ai/cli/commands/configure.py
+++ b/src/venice_ai/cli/commands/configure.py
@@ -206,6 +206,7 @@ def configure_cli(ctx: dict[str, Any]) -> None:
                 print_success(f"Configuration saved to {save_path}")
             except Exception as e:
                 print_error(f"Failed to save configuration: {e}")
+                raise SystemExit(1) from e
         else:
             custom_path = questionary.path(
                 "Enter configuration file path:", default=str(DEFAULT_CONFIG_PATH)
@@ -217,6 +218,7 @@ def configure_cli(ctx: dict[str, Any]) -> None:
                     print_success(f"Configuration saved to {custom_path}")
                 except Exception as e:
                     print_error(f"Failed to save configuration: {e}")
+                    raise SystemExit(1) from e
 
     # Final message
     console.print("\n[bold green]Configuration complete![/bold green]")

--- a/src/venice_ai/cli/commands/image/edit.py
+++ b/src/venice_ai/cli/commands/image/edit.py
@@ -205,8 +205,10 @@ async def _edit_async(
 
     except VeniceError as e:
         print_error(f"Venice API error: {e}")
+        raise SystemExit(1) from e
     except Exception as e:
         print_error(f"Unexpected error: {e}")
+        raise SystemExit(1) from e
 
 
 @click.command(name="remove-bg")
@@ -318,5 +320,7 @@ async def _remove_bg_async(
 
     except VeniceError as e:
         print_error(f"Venice API error: {e}")
+        raise SystemExit(1) from e
     except Exception as e:
         print_error(f"Unexpected error: {e}")
+        raise SystemExit(1) from e

--- a/src/venice_ai/cli/commands/image/generate.py
+++ b/src/venice_ai/cli/commands/image/generate.py
@@ -261,7 +261,7 @@ async def _generate_image_async(
 
             if not is_valid:
                 print_error(f"Parameter validation failed: {error_message}")
-                return
+                raise SystemExit(1)
 
             # Show generation info
             if plain:
@@ -411,8 +411,10 @@ async def _generate_image_async(
 
     except VeniceError as e:
         print_error(f"Venice API error: {e}")
+        raise SystemExit(1) from e
     except Exception as e:
         print_error(f"Unexpected error: {e}")
+        raise SystemExit(1) from e
 
 
 @click.command(name="batch")
@@ -503,7 +505,7 @@ async def _batch_generate_async(
 
     if not prompts:
         print_error("No prompts found in file")
-        return
+        raise SystemExit(1)
 
     print_info(f"Found {len(prompts)} prompt(s) to process")
 
@@ -657,5 +659,7 @@ async def _batch_generate_async(
 
     except VeniceError as e:
         print_error(f"Venice API error: {e}")
+        raise SystemExit(1) from e
     except Exception as e:
         print_error(f"Unexpected error: {e}")
+        raise SystemExit(1) from e

--- a/src/venice_ai/cli/commands/image/multi_edit.py
+++ b/src/venice_ai/cli/commands/image/multi_edit.py
@@ -218,5 +218,7 @@ async def _multi_edit_async(
 
     except VeniceError as e:
         print_error(f"Venice API error: {e}")
+        raise SystemExit(1) from e
     except Exception as e:
         print_error(f"Unexpected error: {e}")
+        raise SystemExit(1) from e

--- a/src/venice_ai/cli/commands/image/styles.py
+++ b/src/venice_ai/cli/commands/image/styles.py
@@ -34,7 +34,7 @@ async def _list_styles_async(ctx: click.Context):
 
             if not response or not response.data:
                 print_error("No styles available")
-                return
+                raise SystemExit(1)
 
             table = Table(
                 title="Available Style Presets",
@@ -53,3 +53,4 @@ async def _list_styles_async(ctx: click.Context):
 
         except Exception as e:
             print_error(f"Failed to fetch styles: {e}")
+            raise SystemExit(1) from e

--- a/src/venice_ai/cli/commands/image/upscale.py
+++ b/src/venice_ai/cli/commands/image/upscale.py
@@ -168,5 +168,7 @@ async def _upscale_async(
 
     except VeniceError as e:
         print_error(f"Venice API error: {e}")
+        raise SystemExit(1) from e
     except Exception as e:
         print_error(f"Unexpected error: {e}")
+        raise SystemExit(1) from e

--- a/src/venice_ai/cli/commands/image/wizard.py
+++ b/src/venice_ai/cli/commands/image/wizard.py
@@ -76,7 +76,7 @@ async def _interactive_image_generation(ctx: click.Context) -> None:
 
             if not prompt:
                 print_error("Prompt is required!")
-                return
+                raise SystemExit(1)
 
             # Model selection
             available = available_models or []
@@ -404,3 +404,4 @@ async def _interactive_image_generation(ctx: click.Context) -> None:
 
     except Exception as e:
         print_error(f"Unexpected error: {e}")
+        raise SystemExit(1) from e

--- a/src/venice_ai/cli/commands/models/command.py
+++ b/src/venice_ai/cli/commands/models/command.py
@@ -105,7 +105,7 @@ async def list_models(
 
                 if len(models_to_compare) < 2:
                     print_error("Need at least 2 models to compare")
-                    return
+                    raise SystemExit(1)
 
                 comparison_table = ModelComparator.compare_models(models_to_compare, currency)
                 if comparison_table:
@@ -117,7 +117,7 @@ async def list_models(
                 model = ModelComparator.find_model_by_id(all_models, detail_id)
                 if not model:
                     print_error(f"Model not found: {detail_id}")
-                    return
+                    raise SystemExit(1)
 
                 panel = ModelFormatter.format_verbose_model(model, currency)
                 console.print(panel)
@@ -232,5 +232,7 @@ async def list_models(
 
     except VeniceError as e:
         print_error(f"Venice API error: {e}")
+        raise SystemExit(1) from e
     except Exception as e:
         print_error(f"Unexpected error: {e}")
+        raise SystemExit(1) from e

--- a/tests/cli/commands/models/test_command.py
+++ b/tests/cli/commands/models/test_command.py
@@ -438,10 +438,11 @@ class TestComparisonMode:
         ):
             MockVeniceClient.return_value.__aenter__.return_value = mock_client
 
-            await list_models(
-                mock_context,
-                compare_ids="test-text-model,nonexistent-model",
-            )
+            with pytest.raises(SystemExit):
+                await list_models(
+                    mock_context,
+                    compare_ids="test-text-model,nonexistent-model",
+                )
 
             # Should print error for missing model
             mock_print_error.assert_any_call("Model not found: nonexistent-model")
@@ -471,10 +472,11 @@ class TestComparisonMode:
         ):
             MockVeniceClient.return_value.__aenter__.return_value = mock_client
 
-            await list_models(
-                mock_context,
-                compare_ids="test-text-model,missing-model",
-            )
+            with pytest.raises(SystemExit):
+                await list_models(
+                    mock_context,
+                    compare_ids="test-text-model,missing-model",
+                )
 
             # Should print error about needing 2 models
             mock_print_error.assert_any_call("Need at least 2 models to compare")
@@ -580,10 +582,11 @@ class TestDetailMode:
         ):
             MockVeniceClient.return_value.__aenter__.return_value = mock_client
 
-            await list_models(
-                mock_context,
-                detail_id="nonexistent-model",
-            )
+            with pytest.raises(SystemExit):
+                await list_models(
+                    mock_context,
+                    detail_id="nonexistent-model",
+                )
 
             # Should print error for missing model
             mock_print_error.assert_any_call("Model not found: nonexistent-model")
@@ -1763,7 +1766,8 @@ class TestErrorHandling:
         ):
             MockVeniceClient.return_value.__aenter__.return_value = mock_client
 
-            await list_models(mock_context)
+            with pytest.raises(SystemExit):
+                await list_models(mock_context)
 
             # Should print Venice API error
             mock_print_error.assert_called()
@@ -1800,7 +1804,8 @@ class TestErrorHandling:
         ):
             MockVeniceClient.return_value.__aenter__.return_value = mock_client
 
-            await list_models(mock_context)
+            with pytest.raises(SystemExit):
+                await list_models(mock_context)
 
             # Should print unexpected error
             mock_print_error.assert_called()

--- a/tests/cli/test_chat_command.py
+++ b/tests/cli/test_chat_command.py
@@ -724,20 +724,21 @@ class TestChatAsync:
             ),
             patch("venice_ai.cli.commands.chat.print_error") as mock_error,
         ):
-            await _chat_async(
-                ctx=mock_ctx,
-                model=None,
-                select_model=True,
-                system_prompt=None,
-                temperature=None,
-                max_completion_tokens=None,
-                stream=True,
-                show_thinking=False,
-                animation="smooth",
-                animation_speed=0.03,
-                show_stats=False,
-                initial_message=None,
-            )
+            with pytest.raises(SystemExit):
+                await _chat_async(
+                    ctx=mock_ctx,
+                    model=None,
+                    select_model=True,
+                    system_prompt=None,
+                    temperature=None,
+                    max_completion_tokens=None,
+                    stream=True,
+                    show_thinking=False,
+                    animation="smooth",
+                    animation_speed=0.03,
+                    show_stats=False,
+                    initial_message=None,
+                )
             mock_error.assert_called_with("No model selected. Exiting.")
 
     @pytest.mark.asyncio
@@ -755,20 +756,21 @@ class TestChatAsync:
             patch("venice_ai.cli.commands.chat.VeniceClient", return_value=mock_client),
             patch("venice_ai.cli.commands.chat.print_error") as mock_error,
         ):
-            await _chat_async(
-                ctx=mock_ctx,
-                model="test-model",
-                select_model=False,
-                system_prompt=None,
-                temperature=None,
-                max_completion_tokens=None,
-                stream=True,
-                show_thinking=False,
-                animation="smooth",
-                animation_speed=0.03,
-                show_stats=False,
-                initial_message="test",
-            )
+            with pytest.raises(SystemExit):
+                await _chat_async(
+                    ctx=mock_ctx,
+                    model="test-model",
+                    select_model=False,
+                    system_prompt=None,
+                    temperature=None,
+                    max_completion_tokens=None,
+                    stream=True,
+                    show_thinking=False,
+                    animation="smooth",
+                    animation_speed=0.03,
+                    show_stats=False,
+                    initial_message="test",
+                )
             mock_error.assert_called()
 
     @pytest.mark.asyncio
@@ -786,20 +788,21 @@ class TestChatAsync:
             patch("venice_ai.cli.commands.chat.VeniceClient", return_value=mock_client),
             patch("venice_ai.cli.commands.chat.print_error") as mock_error,
         ):
-            await _chat_async(
-                ctx=mock_ctx,
-                model="test-model",
-                select_model=False,
-                system_prompt=None,
-                temperature=None,
-                max_completion_tokens=None,
-                stream=True,
-                show_thinking=False,
-                animation="smooth",
-                animation_speed=0.03,
-                show_stats=False,
-                initial_message="test",
-            )
+            with pytest.raises(SystemExit):
+                await _chat_async(
+                    ctx=mock_ctx,
+                    model="test-model",
+                    select_model=False,
+                    system_prompt=None,
+                    temperature=None,
+                    max_completion_tokens=None,
+                    stream=True,
+                    show_thinking=False,
+                    animation="smooth",
+                    animation_speed=0.03,
+                    show_stats=False,
+                    initial_message="test",
+                )
             mock_error.assert_called()
 
     @pytest.mark.asyncio

--- a/tests/cli/test_configure.py
+++ b/tests/cli/test_configure.py
@@ -896,7 +896,8 @@ class TestConfigureCli:
                     ):
                         mock_save.side_effect = Exception("Permission denied")
                         with patch("venice_ai.cli.commands.configure.print_error") as mock_error:
-                            configure_cli({})
+                            with pytest.raises(SystemExit):
+                                configure_cli({})
                             mock_error.assert_called()
 
     def test_configure_cli_save_to_custom_path_success(self):
@@ -996,7 +997,8 @@ class TestConfigureCli:
                     ):
                         mock_save.side_effect = Exception("Permission denied")
                         with patch("venice_ai.cli.commands.configure.print_error") as mock_error:
-                            configure_cli({})
+                            with pytest.raises(SystemExit):
+                                configure_cli({})
                             mock_error.assert_called()
 
     def test_configure_cli_skip_save(self):

--- a/tests/cli/test_image_command_comprehensive.py
+++ b/tests/cli/test_image_command_comprehensive.py
@@ -3842,6 +3842,56 @@ class TestMultiEditCommand:
         assert kwargs["quality"] == "high"
         assert out_file.read_bytes() == result_bytes
 
+    @staticmethod
+    async def _run_multi_edit_failure(mock_ctx, tmp_path, exc):
+        """Drive _multi_edit_async into its error handler; return the mocked reporter."""
+        from venice_ai.cli.commands.image.multi_edit import _multi_edit_async
+
+        paths = [tmp_path / name for name in ("a.png", "b.png", "c.png")]
+        for p in paths:
+            p.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        mock_client = AsyncMock()
+        mock_client.image.multi_edit = AsyncMock(side_effect=exc)
+
+        with (
+            patch("venice_ai.cli.config.ensure_api_key", return_value="test-key"),
+            patch("venice_ai.cli.commands.image.multi_edit.VeniceClient") as MockClient,
+            patch("venice_ai.cli.commands.image.multi_edit.print_error") as mock_err,
+        ):
+            mock_cm = AsyncMock()
+            mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cm.__aexit__ = AsyncMock(return_value=None)
+            MockClient.return_value = mock_cm
+
+            with pytest.raises(SystemExit):
+                await _multi_edit_async(
+                    ctx=mock_ctx,
+                    prompt="combine these",
+                    image=str(paths[0]),
+                    image_2=str(paths[1]),
+                    image_3=str(paths[2]),
+                    model="hidream",
+                    output=str(tmp_path / "out.png"),
+                    aspect_ratio="1:1",
+                    output_format="png",
+                    quality="high",
+                )
+
+        return mock_err
+
+    @pytest.mark.asyncio
+    async def test_multi_edit_async_venice_error(self, mock_ctx, tmp_path):
+        """A Venice API failure is reported and exits non-zero."""
+        mock_err = await self._run_multi_edit_failure(mock_ctx, tmp_path, VeniceError("API Error"))
+        assert "Venice API error" in mock_err.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_multi_edit_async_unexpected_error(self, mock_ctx, tmp_path):
+        """An unexpected failure is reported and exits non-zero."""
+        mock_err = await self._run_multi_edit_failure(mock_ctx, tmp_path, RuntimeError("boom"))
+        assert "Unexpected error" in mock_err.call_args[0][0]
+
     @pytest.mark.asyncio
     async def test_multi_edit_async_single_image(self, mock_ctx, tmp_path):
         """Optional layer images are omitted when not provided."""

--- a/tests/cli/test_image_command_comprehensive.py
+++ b/tests/cli/test_image_command_comprehensive.py
@@ -297,16 +297,17 @@ class TestGenerateImageAsync:
                 ),
                 patch("venice_ai.cli.commands.image.generate.print_error") as mock_error,
             ):
-                await _generate_image_async(
-                    ctx=mock_ctx,
-                    prompt="test",
-                    model="hidream",
-                    size="1024x1024",
-                    num_images=1,
-                    output=None,
-                    save_dir=None,
-                    show_timing=True,
-                )
+                with pytest.raises(SystemExit):
+                    await _generate_image_async(
+                        ctx=mock_ctx,
+                        prompt="test",
+                        model="hidream",
+                        size="1024x1024",
+                        num_images=1,
+                        output=None,
+                        save_dir=None,
+                        show_timing=True,
+                    )
                 mock_error.assert_called_once()
 
     @pytest.mark.asyncio
@@ -451,16 +452,17 @@ class TestGenerateImageAsync:
         ):
             MockClient.return_value.__aenter__ = AsyncMock(side_effect=VeniceError("API Error"))
             with patch("venice_ai.cli.commands.image.generate.print_error") as mock_error:
-                await _generate_image_async(
-                    ctx=mock_ctx,
-                    prompt="test",
-                    model="hidream",
-                    size="1024x1024",
-                    num_images=1,
-                    output=None,
-                    save_dir=None,
-                    show_timing=True,
-                )
+                with pytest.raises(SystemExit):
+                    await _generate_image_async(
+                        ctx=mock_ctx,
+                        prompt="test",
+                        model="hidream",
+                        size="1024x1024",
+                        num_images=1,
+                        output=None,
+                        save_dir=None,
+                        show_timing=True,
+                    )
                 mock_error.assert_called()
 
     @pytest.mark.asyncio
@@ -478,16 +480,17 @@ class TestGenerateImageAsync:
                 side_effect=RuntimeError("Unexpected error")
             )
             with patch("venice_ai.cli.commands.image.generate.print_error") as mock_error:
-                await _generate_image_async(
-                    ctx=mock_ctx,
-                    prompt="test",
-                    model="hidream",
-                    size="1024x1024",
-                    num_images=1,
-                    output=None,
-                    save_dir=None,
-                    show_timing=True,
-                )
+                with pytest.raises(SystemExit):
+                    await _generate_image_async(
+                        ctx=mock_ctx,
+                        prompt="test",
+                        model="hidream",
+                        size="1024x1024",
+                        num_images=1,
+                        output=None,
+                        save_dir=None,
+                        show_timing=True,
+                    )
                 mock_error.assert_called()
 
     @pytest.mark.asyncio
@@ -527,16 +530,17 @@ class TestGenerateImageAsync:
                     patch("venice_ai.cli.commands.image.generate.print_error") as mock_error,
                 ):
                     # The function catches exceptions and calls print_error
-                    await _generate_image_async(
-                        ctx=mock_ctx,
-                        prompt="test",
-                        model="hidream",
-                        size="1024x1024",
-                        num_images=1,
-                        output=None,
-                        save_dir=None,
-                        show_timing=True,
-                    )
+                    with pytest.raises(SystemExit):
+                        await _generate_image_async(
+                            ctx=mock_ctx,
+                            prompt="test",
+                            model="hidream",
+                            size="1024x1024",
+                            num_images=1,
+                            output=None,
+                            save_dir=None,
+                            show_timing=True,
+                        )
                     # Verify error was reported
                     mock_error.assert_called()
 
@@ -656,6 +660,7 @@ class TestInteractiveImageGeneration:
             with (
                 patch("asyncio.to_thread", return_value=None),  # Prompt returns None
                 patch("venice_ai.cli.commands.image.wizard.print_error"),
+                pytest.raises(SystemExit),
             ):
                 await _interactive_image_generation(mock_ctx)
 
@@ -683,6 +688,7 @@ class TestInteractiveImageGeneration:
             with (
                 patch("asyncio.to_thread", return_value=None),  # Empty prompt
                 patch("venice_ai.cli.commands.image.wizard.print_error"),
+                pytest.raises(SystemExit),
             ):
                 await _interactive_image_generation(mock_ctx)
 
@@ -716,6 +722,7 @@ class TestInteractiveImageGeneration:
             with (
                 patch("asyncio.to_thread", return_value=None),
                 patch("venice_ai.cli.commands.image.wizard.print_error"),
+                pytest.raises(SystemExit),
             ):
                 await _interactive_image_generation(mock_ctx)
 
@@ -730,7 +737,10 @@ class TestInteractiveImageGeneration:
             patch("venice_ai.cli.commands.image.wizard.VeniceClient") as MockClient,
         ):
             MockClient.return_value.__aenter__ = AsyncMock(side_effect=Exception("Wizard error"))
-            with patch("venice_ai.cli.commands.image.wizard.print_error"):
+            with (
+                patch("venice_ai.cli.commands.image.wizard.print_error"),
+                pytest.raises(SystemExit),
+            ):
                 await _interactive_image_generation(mock_ctx)
 
 
@@ -1015,6 +1025,7 @@ class TestInteractiveFlowPaths:
             with (
                 patch("asyncio.to_thread", side_effect=mock_to_thread),
                 patch("venice_ai.cli.commands.image.wizard.print_info"),
+                pytest.raises(SystemExit),
             ):
                 await _interactive_image_generation(mock_ctx)
 
@@ -1254,6 +1265,7 @@ class TestListStylesAsync:
             with (
                 patch("venice_ai.cli.commands.image.styles.print_info"),
                 patch("venice_ai.cli.commands.image.styles.print_error"),
+                pytest.raises(SystemExit),
             ):
                 await _list_styles_async(mock_ctx)
 
@@ -1275,6 +1287,7 @@ class TestListStylesAsync:
             with (
                 patch("venice_ai.cli.commands.image.styles.print_info"),
                 patch("venice_ai.cli.commands.image.styles.print_error"),
+                pytest.raises(SystemExit),
             ):
                 await _list_styles_async(mock_ctx)
 
@@ -1326,13 +1339,14 @@ class TestBatchGenerateAsync:
             mock_ctx.obj["config"] = mock_config
 
             with patch("venice_ai.cli.commands.image.generate.print_error") as mock_error:
-                await _batch_generate_async(
-                    ctx=mock_ctx,
-                    prompts_file=str(prompts_file),
-                    model="hidream",
-                    size="1024x1024",
-                    save_dir=None,
-                )
+                with pytest.raises(SystemExit):
+                    await _batch_generate_async(
+                        ctx=mock_ctx,
+                        prompts_file=str(prompts_file),
+                        model="hidream",
+                        size="1024x1024",
+                        save_dir=None,
+                    )
                 mock_error.assert_called()
 
     @pytest.mark.asyncio
@@ -1465,7 +1479,10 @@ class TestBatchGenerateAsync:
                 patch("venice_ai.cli.commands.image.generate.VeniceClient") as MockClient,
             ):
                 MockClient.return_value.__aenter__ = AsyncMock(side_effect=VeniceError("API Error"))
-                with patch("venice_ai.cli.commands.image.generate.print_error"):
+                with (
+                    patch("venice_ai.cli.commands.image.generate.print_error"),
+                    pytest.raises(SystemExit),
+                ):
                     await _batch_generate_async(
                         ctx=mock_ctx,
                         prompts_file=str(prompts_file),
@@ -1493,7 +1510,10 @@ class TestBatchGenerateAsync:
                 MockClient.return_value.__aenter__ = AsyncMock(
                     side_effect=RuntimeError("Unexpected")
                 )
-                with patch("venice_ai.cli.commands.image.generate.print_error"):
+                with (
+                    patch("venice_ai.cli.commands.image.generate.print_error"),
+                    pytest.raises(SystemExit),
+                ):
                     await _batch_generate_async(
                         ctx=mock_ctx,
                         prompts_file=str(prompts_file),
@@ -1608,6 +1628,7 @@ class TestEdgeCases:
             with (
                 patch("asyncio.to_thread", side_effect=mock_to_thread),
                 patch("venice_ai.cli.commands.image.wizard.print_info"),
+                pytest.raises(SystemExit),
             ):
                 await _interactive_image_generation(mock_ctx)
 
@@ -1661,6 +1682,7 @@ class TestEdgeCases:
             with (
                 patch("asyncio.to_thread", side_effect=mock_to_thread),
                 patch("venice_ai.cli.commands.image.wizard.print_info"),
+                pytest.raises(SystemExit),
             ):
                 await _interactive_image_generation(mock_ctx)
 
@@ -1714,6 +1736,7 @@ class TestEdgeCases:
             with (
                 patch("asyncio.to_thread", side_effect=mock_to_thread),
                 patch("venice_ai.cli.commands.image.wizard.print_info"),
+                pytest.raises(SystemExit),
             ):
                 await _interactive_image_generation(mock_ctx)
 
@@ -2022,16 +2045,17 @@ class TestGenerateImageAsyncPlainMode:
                     patch("click.echo"),
                 ):
                     # Should not raise despite the exception
-                    await _generate_image_async(
-                        ctx=plain_ctx,
-                        prompt="test prompt",
-                        model="hidream",
-                        size="1024x1024",
-                        num_images=1,
-                        output=None,
-                        save_dir=tmpdir,
-                        show_timing=False,
-                    )
+                    with pytest.raises(SystemExit):
+                        await _generate_image_async(
+                            ctx=plain_ctx,
+                            prompt="test prompt",
+                            model="hidream",
+                            size="1024x1024",
+                            num_images=1,
+                            output=None,
+                            save_dir=tmpdir,
+                            show_timing=False,
+                        )
                     # The outer except catches and calls print_error
                     # Either click.echo was called with failure message or print_error was called
                     assert True  # Just verify it didn't crash
@@ -2569,18 +2593,19 @@ class TestUpscaleAsync:
             MockClient.return_value = mock_cm
 
             with patch("venice_ai.cli.commands.image.upscale.print_error") as mock_err:
-                await _upscale_async(
-                    ctx=rich_ctx,
-                    input_file=str(input_file),
-                    scale=None,
-                    enhance=None,
-                    enhance_creativity=None,
-                    enhance_prompt=None,
-                    replication=None,
-                    output=None,
-                    save_dir=str(tmp_path),
-                    open_image=False,
-                )
+                with pytest.raises(SystemExit):
+                    await _upscale_async(
+                        ctx=rich_ctx,
+                        input_file=str(input_file),
+                        scale=None,
+                        enhance=None,
+                        enhance_creativity=None,
+                        enhance_prompt=None,
+                        replication=None,
+                        output=None,
+                        save_dir=str(tmp_path),
+                        open_image=False,
+                    )
                 mock_err.assert_called()
 
     @pytest.mark.asyncio
@@ -2605,18 +2630,19 @@ class TestUpscaleAsync:
                 patch("venice_ai.cli.commands.image.upscale.print_error"),
                 patch("click.echo") as mock_echo,
             ):
-                await _upscale_async(
-                    ctx=plain_ctx,
-                    input_file=str(input_file),
-                    scale=None,
-                    enhance=None,
-                    enhance_creativity=None,
-                    enhance_prompt=None,
-                    replication=None,
-                    output=None,
-                    save_dir=str(tmp_path),
-                    open_image=False,
-                )
+                with pytest.raises(SystemExit):
+                    await _upscale_async(
+                        ctx=plain_ctx,
+                        input_file=str(input_file),
+                        scale=None,
+                        enhance=None,
+                        enhance_creativity=None,
+                        enhance_prompt=None,
+                        replication=None,
+                        output=None,
+                        save_dir=str(tmp_path),
+                        open_image=False,
+                    )
                 echo_str = " ".join(str(c) for c in mock_echo.call_args_list)
                 assert "failed" in echo_str.lower() or "Upscaling" in echo_str
 
@@ -2639,18 +2665,19 @@ class TestUpscaleAsync:
             MockClient.return_value = mock_cm
 
             with patch("venice_ai.cli.commands.image.upscale.print_error") as mock_err:
-                await _upscale_async(
-                    ctx=plain_ctx,
-                    input_file=str(input_file),
-                    scale=None,
-                    enhance=None,
-                    enhance_creativity=None,
-                    enhance_prompt=None,
-                    replication=None,
-                    output=None,
-                    save_dir=str(tmp_path),
-                    open_image=False,
-                )
+                with pytest.raises(SystemExit):
+                    await _upscale_async(
+                        ctx=plain_ctx,
+                        input_file=str(input_file),
+                        scale=None,
+                        enhance=None,
+                        enhance_creativity=None,
+                        enhance_prompt=None,
+                        replication=None,
+                        output=None,
+                        save_dir=str(tmp_path),
+                        open_image=False,
+                    )
                 mock_err.assert_called()
                 assert "Venice API error" in mock_err.call_args[0][0]
 
@@ -2830,16 +2857,17 @@ class TestEditAsync:
                 patch("venice_ai.cli.commands.image.edit.print_error"),
                 patch("click.echo") as mock_echo,
             ):
-                await _edit_async(
-                    ctx=plain_ctx,
-                    input_file=str(input_file),
-                    prompt="Edit prompt",
-                    model=None,
-                    output=None,
-                    save_dir=str(tmp_path),
-                    img_format=None,
-                    open_image=False,
-                )
+                with pytest.raises(SystemExit):
+                    await _edit_async(
+                        ctx=plain_ctx,
+                        input_file=str(input_file),
+                        prompt="Edit prompt",
+                        model=None,
+                        output=None,
+                        save_dir=str(tmp_path),
+                        img_format=None,
+                        open_image=False,
+                    )
                 echo_str = " ".join(str(c) for c in mock_echo.call_args_list)
                 assert "failed" in echo_str.lower() or "Edit" in echo_str
 
@@ -2863,16 +2891,17 @@ class TestEditAsync:
             MockClient.return_value = mock_cm
 
             with patch("venice_ai.cli.commands.image.edit.print_error") as mock_err:
-                await _edit_async(
-                    ctx=rich_ctx,
-                    input_file=str(input_file),
-                    prompt="Test",
-                    model=None,
-                    output=None,
-                    save_dir=str(tmp_path),
-                    img_format=None,
-                    open_image=False,
-                )
+                with pytest.raises(SystemExit):
+                    await _edit_async(
+                        ctx=rich_ctx,
+                        input_file=str(input_file),
+                        prompt="Test",
+                        model=None,
+                        output=None,
+                        save_dir=str(tmp_path),
+                        img_format=None,
+                        open_image=False,
+                    )
                 mock_err.assert_called()
 
     @pytest.mark.asyncio
@@ -2894,16 +2923,17 @@ class TestEditAsync:
             MockClient.return_value = mock_cm
 
             with patch("venice_ai.cli.commands.image.edit.print_error") as mock_err:
-                await _edit_async(
-                    ctx=plain_ctx,
-                    input_file=str(input_file),
-                    prompt="Test",
-                    model=None,
-                    output=None,
-                    save_dir=str(tmp_path),
-                    img_format=None,
-                    open_image=False,
-                )
+                with pytest.raises(SystemExit):
+                    await _edit_async(
+                        ctx=plain_ctx,
+                        input_file=str(input_file),
+                        prompt="Test",
+                        model=None,
+                        output=None,
+                        save_dir=str(tmp_path),
+                        img_format=None,
+                        open_image=False,
+                    )
                 mock_err.assert_called()
                 assert "Venice API error" in mock_err.call_args[0][0]
 
@@ -3282,14 +3312,15 @@ class TestRemoveBgAsync:
                 patch("venice_ai.cli.commands.image.edit.print_error"),
                 patch("click.echo") as mock_echo,
             ):
-                await _remove_bg_async(
-                    ctx=plain_ctx,
-                    input_file=str(input_file),
-                    output=None,
-                    save_dir=str(tmp_path),
-                    img_format="png",
-                    open_image=False,
-                )
+                with pytest.raises(SystemExit):
+                    await _remove_bg_async(
+                        ctx=plain_ctx,
+                        input_file=str(input_file),
+                        output=None,
+                        save_dir=str(tmp_path),
+                        img_format="png",
+                        open_image=False,
+                    )
                 echo_str = " ".join(str(c) for c in mock_echo.call_args_list)
                 assert "failed" in echo_str.lower() or "removal" in echo_str.lower()
 
@@ -3313,14 +3344,15 @@ class TestRemoveBgAsync:
             MockClient.return_value = mock_cm
 
             with patch("venice_ai.cli.commands.image.edit.print_error") as mock_err:
-                await _remove_bg_async(
-                    ctx=rich_ctx,
-                    input_file=str(input_file),
-                    output=None,
-                    save_dir=str(tmp_path),
-                    img_format="png",
-                    open_image=False,
-                )
+                with pytest.raises(SystemExit):
+                    await _remove_bg_async(
+                        ctx=rich_ctx,
+                        input_file=str(input_file),
+                        output=None,
+                        save_dir=str(tmp_path),
+                        img_format="png",
+                        open_image=False,
+                    )
                 mock_err.assert_called()
 
     @pytest.mark.asyncio
@@ -3342,14 +3374,15 @@ class TestRemoveBgAsync:
             MockClient.return_value = mock_cm
 
             with patch("venice_ai.cli.commands.image.edit.print_error") as mock_err:
-                await _remove_bg_async(
-                    ctx=plain_ctx,
-                    input_file=str(input_file),
-                    output=None,
-                    save_dir=str(tmp_path),
-                    img_format="png",
-                    open_image=False,
-                )
+                with pytest.raises(SystemExit):
+                    await _remove_bg_async(
+                        ctx=plain_ctx,
+                        input_file=str(input_file),
+                        output=None,
+                        save_dir=str(tmp_path),
+                        img_format="png",
+                        open_image=False,
+                    )
                 mock_err.assert_called()
                 assert "Venice API error" in mock_err.call_args[0][0]
 
@@ -3563,16 +3596,17 @@ class TestGenerateImageParameterValidationFailure:
                 ),
                 patch("venice_ai.cli.commands.image.generate.print_error") as mock_err,
             ):
-                await _generate_image_async(
-                    ctx=mock_ctx,
-                    prompt="test",
-                    model="hidream",
-                    size="1024x1024",
-                    num_images=1,
-                    output=None,
-                    save_dir=str(tmp_path),
-                    show_timing=False,
-                )
+                with pytest.raises(SystemExit):
+                    await _generate_image_async(
+                        ctx=mock_ctx,
+                        prompt="test",
+                        model="hidream",
+                        size="1024x1024",
+                        num_images=1,
+                        output=None,
+                        save_dir=str(tmp_path),
+                        show_timing=False,
+                    )
                 mock_err.assert_called()
                 assert "Parameter validation failed" in mock_err.call_args[0][0]
 

--- a/tests/cli/test_interactive.py
+++ b/tests/cli/test_interactive.py
@@ -682,7 +682,8 @@ class TestInteractiveWizardErrorHandling:
             # Return empty prompt
             mock_to_thread.return_value = ""
 
-            await _interactive_image_generation(mock_click_context)
+            with pytest.raises(SystemExit):
+                await _interactive_image_generation(mock_click_context)
 
             # Verify error was shown
             mock_console_functions["error"].assert_called_with("Prompt is required!")


### PR DESCRIPTION
## The bug

CLI commands reported failures and then exited **0**, so scripts could not distinguish success from failure:

```console
$ venice image generate "a cat" --size 999x999
❌ Error: Parameter validation failed: Width must be divisible by 8 (got 999)
$ echo $?
0
```

Same for every API error, and for a missing API key. Any `venice ... && next-step` chain proceeded as though the command had succeeded.

## Two shapes, not one

An AST sweep found the failure reporting split across two patterns:

| Shape | Found | Fixed | Left |
|---|---|---|---|
| `except` handler reports, falls through | 30 | 20 | 10 |
| `print_error(...)` + bare `return` | 11 | 7 | 4 |

The second shape is what the size-validation path used, so fixing only the handlers would have left the original symptom intact.

## Deliberately unchanged

- **Helpers that signal via return value** (`presets.py`, model selection) — the caller owns the exit code
- **Interactive re-prompt paths** in `venice configure` — continuing is the intent
- **The chat REPL** — API errors must not end an interactive session, and a fatal error still `break`s so the conversation-save path runs rather than discarding the user's chat

## Verification

```
invalid size       exit=1   (was 0)
missing api key    exit=1   (was 0)
--help             exit=0   (unchanged)
root --help        exit=0   (unchanged)
```

Full deterministic gate green locally: **4420 passed, 93% coverage**. ruff, mypy, and `vulture src/ --min-confidence 80` all clean.

39 tests asserted the old contract (call the async helper, expect a normal return). They now assert `SystemExit`; their existing output assertions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)