### PR TITLE
Repair the docs workflow: broken deploy and broken type-check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,8 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          # 22 is the floor for wrangler 4.122.0, which the deploy step pins.
+          node-version: '22'
           cache: npm
           cache-dependency-path: website/package-lock.json
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,6 +56,11 @@ jobs:
         working-directory: website
         run: npm run build
 
+      # Runs after the build so the generated .docusaurus/ types are on disk.
+      - name: Type-check the site
+        working-directory: website
+        run: npm run typecheck
+
       - name: Deploy to Cloudflare Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0  # v4.0.0

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,7 +1,8 @@
+import type {ReactNode} from 'react';
 import {Redirect} from '@docusaurus/router';
 
 // This is a single-SDK documentation site, so the root sends visitors straight
 // to the docs rather than a standalone splash page.
-export default function Home(): JSX.Element {
+export default function Home(): ReactNode {
   return <Redirect to="/docs/getting-started" />;
 }


### PR DESCRIPTION
Two independent faults in the docs workflow, both currently live on `main`.

## 1. The Cloudflare deploy is broken (regression from #17)

Every push to `main` since `dcff906` has failed at the deploy step:

```
Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.
```

wrangler 4.122.0 declares `engines.node >=22.0.0`; the workflow ran Node 20.

This is a regression from the `wranglerVersion: '4.122.0'` pin added in #17.
Before that pin, wrangler-action ran `npm i wrangler@4` and npm resolved it to
**4.86.0** — the newest 4.x that Node 20 could satisfy. The floating default was
silently absorbing the mismatch; pinning an exact version removed that cushion.

Fix: `node-version: '20'` → `'22'`. Docusaurus requires only `>=20.0`, so
raising the runtime is the smaller change and keeps the deploy reproducible.
The site is still serving its last good deployment, but everything merged since
`dcff906` — including the Docusaurus 3.10.2 build — has not shipped.

## 2. `npm run typecheck` is broken, and nothing runs it

```
src/pages/index.tsx:5:5 - error TS2503: Cannot find namespace 'JSX'.
```

React 19's types removed the global `JSX` namespace. `@types/react` has been
`^19.0.0` since the v2.0.0 squash and `index.tsx` has never been edited since,
so this dates from the site's first commit. No workflow ran the script, so it
rotted unnoticed.

Fix: return `ReactNode`, the signature Docusaurus 3 uses in its own templates,
and run `npm run typecheck` in the workflow — after the build, so the generated
`.docusaurus/` types are on disk. A failure now blocks the deploy step.

## Verification

`npm run typecheck` exits 0 locally (was 2). `npm run build` passes on Node 24.
The deploy fix is verified by this workflow's own run on merge.

## Related

#23 (TypeScript 6 → 7) was closed as blocked upstream: TypeScript 7 removed the
`baseUrl` compiler option and `@docusaurus/tsconfig` still sets it.