### PR TITLE
Restore patched yaml and minimatch under docusaurus-plugin-llms

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8733,12 +8733,12 @@
       }
     },
     "node_modules/docusaurus-plugin-llms/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -19477,15 +19477,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/website/package.json
+++ b/website/package.json
@@ -36,7 +36,9 @@
     "typescript": "~6.0.2"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "minimatch@9.0.3": "9.0.9",
+    "yaml@2.8.1": "2.9.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
The `docusaurus-plugin-llms` 0.4.0 → 0.5.1 bump in #18 pulled two packages
*backwards* into known advisories. Upstream switched from caret ranges to exact
pins, and the pinned versions are vulnerable:

| | 0.4.0 | 0.5.1 |
|---|---|---|
| minimatch | `^9.0.3` → resolved **9.0.9** | `9.0.3` → **9.0.3** (3 advisories) |
| yaml | `^2.8.1` → resolved **2.9.0** | `2.8.1` → **2.8.1** (1 advisory) |

Trivy findings on the lockfile went 3 → 7. This restores the versions the
previous range already resolved to, so it's a return to the prior state rather
than a new upgrade.

## Why the overrides are keyed by version, not by parent

The obvious form is a parent-scoped override:

```json
"overrides": { "docusaurus-plugin-llms": { "minimatch": "^9.0.7" } }
```

That is wrong here. It collapses the whole tree onto a single minimatch, which
drags `serve-handler` off the `3.1.5` it pins exactly — verified: the resulting
lockfile had one `node_modules/minimatch` at 9.0.9 and no 3.x copy at all.

Keying on `minimatch@9.0.3` touches only the plugin's own nested copy:

```
9.0.9   node_modules/docusaurus-plugin-llms/node_modules/minimatch
3.1.5   node_modules/minimatch          <- serve-handler's, untouched
2.9.0   node_modules/yaml
```

## Verification

- `npm run build` exits 0; the plugin still emits `llms.txt`, `llms-full.txt` and
  `llms-api.txt` across 80 documents — which matters, since this overrides the
  plugin's own dependencies.
- `npm run typecheck` exits 0.
- Trivy, using the CI invocation, reports **1** alert (`uuid`, knowingly
  retained), down from 7.