### PR TITLE
fix: accept mapping messages in chat.completions type hints (#1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-08-12
+
+### Fixed
+
+- **`messages=` now type-checks with plain dicts.** The parameter was annotated `Sequence[UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage]`, which is narrower than what the code actually accepts: mappings in the OpenAI wire shape (`{"role": "user", "content": "hi"}`) have always been validated and coerced into the corresponding message model, but type checkers rejected them (`error: List item 0 has incompatible type "dict[str, str]"`). The annotation is now the public `ChatMessageParam` union, so both forms check cleanly on `create()`, `stream()`, `parse()`, `estimate_cost()`, and `run_with_tools()`. The typed models remain the documented idiom — they give completion and validation at construction — and malformed mappings still raise `ValidationError` before the request is sent. Reported in [#1](https://github.com/sethbang/venice-ai/issues/1).
+- **`estimate_cost()` and `run_with_tools()` accept mapping messages.** Both read the message list before it reaches the request model, so dict input previously raised `AttributeError` on `.content` (`estimate_cost`) or left raw dicts in the returned `ToolLoopResult.messages` history (`run_with_tools`). Messages are now normalized at the method boundary.
+
+### Added
+
+- **`ChatMessageParam`** (exported from `venice_ai.types`) — the union describing what `messages=` accepts: any of the five message models, or a plain `Mapping[str, Any]`. Use it to annotate your own message-building helpers. Note that `ChatCompletionRequest.messages` deliberately stays model-only; it is the validation boundary where mappings are coerced.
+
 ## [2.0.0] - 2026-08-12
 
 ### Breaking Changes

--- a/examples/best_practices/pydantic_models.py
+++ b/examples/best_practices/pydantic_models.py
@@ -163,10 +163,13 @@ def example_message_models_anti_patterns():
     print("Section 1: Message Models - ANTI-PATTERNS (What NOT to Do)")
     print("=" * 70)
 
-    print("\n❌ WRONG: Using plain dicts instead of Pydantic models")
-    print("   # DON'T DO THIS:")
+    print("\n⚠️  WEAKER: Building messages as plain dicts")
+    print("   # ACCEPTED, BUT PREFER THE MODEL:")
     print("   # user_msg = {'role': 'user', 'content': 'Hello'}")
-    print("   # This bypasses all validation and type checking!")
+    print("   # Dicts are validated into UserMessage when the request is built,")
+    print("   # so a bad role still raises - but only once you call the API.")
+    print("   # UserMessage(content='Hello') fails at construction instead,")
+    print("   # and gives you editor completion on the fields.")
 
     print("\n❌ WRONG: Dict-style access on Pydantic models")
     print("   # DON'T DO THIS:")
@@ -188,7 +191,7 @@ def example_message_models_anti_patterns():
     print("   # user_msg.role = 'assistant'  # Wrong role!")
     print("   # INSTEAD: Create a new message object")
 
-    print("\n💡 Key Takeaway: Always use Pydantic models, never plain dicts!")
+    print("\n💡 Key Takeaway: Prefer the Pydantic models - they catch mistakes earlier!")
 
 
 def example_validation_rejections_live():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "venice-ai"
-version = "2.0.0"
+version = "2.0.1"
 description = "Unofficial, community-maintained Python client library for interacting with the Venice.ai API, offering comprehensive access to its features with unified architecture and intelligent rate limiting."
 readme = "README.md"
 license = "MIT"

--- a/src/venice_ai/__init__.py
+++ b/src/venice_ai/__init__.py
@@ -401,4 +401,4 @@ try:
 
     __version__ = _pkg_version("venice-ai")
 except Exception:  # pragma: no cover - source tree without installed metadata
-    __version__ = "2.0.0"
+    __version__ = "2.0.1"

--- a/src/venice_ai/resources/chat/completions.py
+++ b/src/venice_ai/resources/chat/completions.py
@@ -82,7 +82,7 @@ from typing import (
     overload,
 )
 
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 
 from ..._resource import APIResource
 from ...costs import ChatCostEstimate
@@ -97,6 +97,7 @@ from ...types.api import (
     ChatCompletionRequest,
     # Response models
     ChatCompletionResponse,
+    ChatMessageParam,
     DeveloperMessage,
     JSONObjectFormat,
     JSONSchemaFormat,
@@ -241,10 +242,25 @@ async def _execute_tool_call(
     return result if isinstance(result, str) else str(result)
 
 
+_ChatMessageModel = UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage
+
+_MESSAGE_LIST_ADAPTER: TypeAdapter[list[_ChatMessageModel]] = TypeAdapter(list[_ChatMessageModel])
+
+
+def _coerce_messages(messages: Sequence[ChatMessageParam]) -> list[_ChatMessageModel]:
+    """Validate a caller's messages into the concrete message models.
+
+    :meth:`ChatCompletions.create` gets this for free, since
+    ``ChatCompletionRequest`` coerces mappings while building the request
+    body. Methods that read or accumulate messages *before* that point need
+    it explicitly, so that a caller passing plain dicts doesn't hit an
+    ``AttributeError`` on ``.content``.
+    """
+    return _MESSAGE_LIST_ADAPTER.validate_python(list(messages))
+
+
 def _concat_message_text(
-    messages: Sequence[
-        UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage
-    ],
+    messages: Sequence[_ChatMessageModel],
 ) -> str:
     """Concatenate plain-text content across a message list.
 
@@ -461,9 +477,7 @@ class ChatCompletions(APIResource["VeniceClient"]):
         self,
         *,
         model: str,
-        messages: Sequence[
-            UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage
-        ],
+        messages: Sequence[ChatMessageParam],
         stream: Literal[False] = False,  # Explicit non-streaming case
         # --- Common Optional Parameters ---
         frequency_penalty: float | None = None,
@@ -514,9 +528,7 @@ class ChatCompletions(APIResource["VeniceClient"]):
         self,
         *,
         model: str,
-        messages: Sequence[
-            UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage
-        ],
+        messages: Sequence[ChatMessageParam],
         stream: Literal[True],
         stream_cls: type[ChunkModelFactory[ChatCompletionChunk]] | None = None,
         # --- Common Optional Parameters ---
@@ -566,9 +578,7 @@ class ChatCompletions(APIResource["VeniceClient"]):
         self,
         *,
         model: str,
-        messages: Sequence[
-            UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage
-        ],
+        messages: Sequence[ChatMessageParam],
         stream: bool = False,
         stream_cls: type[ChunkModelFactory[ChatCompletionChunk]] | None = None,
         **kwargs: Any,  # Catch all other keyword args
@@ -594,7 +604,12 @@ class ChatCompletions(APIResource["VeniceClient"]):
             messages: Sequence of messages forming the conversation. Each
                 entry is one of :class:`UserMessage`, :class:`AssistantMessage`,
                 :class:`SystemMessage`, :class:`ToolMessage`, or
-                :class:`DeveloperMessage`.
+                :class:`DeveloperMessage` — or a plain mapping in the same
+                shape (``{"role": "user", "content": "hi"}``), which is
+                validated into the matching model before the request is
+                built. The models are preferred: they give editor completion
+                and raise on a bad field at construction rather than at call
+                time.
             stream: If ``True``, stream back partial progress as
                 ``AsyncIterator[ChatCompletionChunk]``. Defaults to ``False``,
                 which returns a single :class:`ChatCompletionResponse`.
@@ -894,7 +909,7 @@ class ChatCompletions(APIResource["VeniceClient"]):
         # Create Pydantic request model
         chat_request = ChatCompletionRequest(
             model=model,
-            messages=list(messages),  # Convert Sequence to List for Pydantic
+            messages=_coerce_messages(messages),  # Mappings validated into message models
             stream=stream,
             **api_params,
         )
@@ -1094,9 +1109,7 @@ class ChatCompletions(APIResource["VeniceClient"]):
         self,
         *,
         model: str,
-        messages: Sequence[
-            UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage
-        ],
+        messages: Sequence[ChatMessageParam],
         e2ee: bool | TeeOptions = False,
         **kwargs: Any,
     ) -> ChatStream:
@@ -1150,9 +1163,7 @@ class ChatCompletions(APIResource["VeniceClient"]):
         self,
         *,
         model: str,
-        messages: Sequence[
-            UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage
-        ],
+        messages: Sequence[ChatMessageParam],
         expected_completion_tokens: int = 500,
         tokens_per_word: float = 1.3,
     ) -> ChatCostEstimate:
@@ -1199,7 +1210,7 @@ class ChatCompletions(APIResource["VeniceClient"]):
         """
         pricing = await self._fetch_chat_pricing(model)
 
-        prompt_text = _concat_message_text(messages)
+        prompt_text = _concat_message_text(_coerce_messages(messages))
         prompt_tokens = int(len(prompt_text.split()) * tokens_per_word)
 
         input_usd = Decimal(str(pricing.input.usd or 0.0))
@@ -1222,9 +1233,7 @@ class ChatCompletions(APIResource["VeniceClient"]):
         self,
         *,
         model: str,
-        messages: Sequence[
-            UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage
-        ],
+        messages: Sequence[ChatMessageParam],
         response_format: type[T],
         schema_name: str | None = None,
         strict: bool = True,
@@ -1416,9 +1425,7 @@ class ChatCompletions(APIResource["VeniceClient"]):
         self,
         *,
         model: str,
-        messages: Sequence[
-            UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage
-        ],
+        messages: Sequence[ChatMessageParam],
         tools: Sequence[Callable[..., Any] | Tool],
         on_tool_call: Callable[[ToolCall, Any], None] | None = None,
         on_tool_error: Callable[[ToolCall, Exception], str] | None = None,
@@ -1503,9 +1510,7 @@ class ChatCompletions(APIResource["VeniceClient"]):
         tool_defs = [entry.tool for entry in registry.values()]
         on_error = on_tool_error or _default_on_tool_error
 
-        history: list[
-            UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage
-        ] = list(messages)
+        history: list[_ChatMessageModel] = _coerce_messages(messages)
 
         last_response: ChatCompletionResponse | None = None
         for iteration in range(1, max_iterations + 1):

--- a/src/venice_ai/types/__init__.py
+++ b/src/venice_ai/types/__init__.py
@@ -90,6 +90,7 @@ from .api import (
     ChatCompletionTokenLogprob,
     ChatCompletionTopLogprob,
     ChatMessage,
+    ChatMessageParam,
     ChatUsage,
     # From streaming module
     ChunkModelFactory,
@@ -462,6 +463,7 @@ __all__ = [
     "AssistantMessage",
     "ToolMessage",
     "SystemMessage",
+    "ChatMessageParam",
     "DeveloperMessage",
     "StreamOptions",
     "ToolFunction",

--- a/src/venice_ai/types/api/__init__.py
+++ b/src/venice_ai/types/api/__init__.py
@@ -169,6 +169,7 @@ from .requests import (
     AudioTranscriptionRequest,
     BillingUsageHistoryQueryParams,
     ChatCompletionRequest,
+    ChatMessageParam,
     # API key models
     ConsumptionLimit,
     CreateApiKeyRequest,
@@ -442,6 +443,7 @@ __all__ = [
     "AssistantMessage",
     "ToolMessage",
     "SystemMessage",
+    "ChatMessageParam",
     "DeveloperMessage",
     "StreamOptions",
     "ToolFunction",

--- a/src/venice_ai/types/api/requests/__init__.py
+++ b/src/venice_ai/types/api/requests/__init__.py
@@ -23,6 +23,7 @@ from .chat import (
     AssistantMessage,
     # Request model
     ChatCompletionRequest,
+    ChatMessageParam,
     DeveloperMessage,
     SystemMessage,
     ToolMessage,
@@ -124,6 +125,7 @@ __all__ = [
     "AssistantMessage",
     "ToolMessage",
     "SystemMessage",
+    "ChatMessageParam",
     "DeveloperMessage",
     # Chat completion
     "ChatCompletionRequest",

--- a/src/venice_ai/types/api/requests/chat.py
+++ b/src/venice_ai/types/api/requests/chat.py
@@ -4,6 +4,7 @@ Chat completion request models for Venice.ai API.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -187,9 +188,27 @@ class DeveloperMessage(BaseModel):
     name: str | None = None
 
 
-# ============================================================================
-# Chat Completion Request
-# ============================================================================
+ChatMessageParam = (
+    UserMessage
+    | AssistantMessage
+    | SystemMessage
+    | ToolMessage
+    | DeveloperMessage
+    | Mapping[str, Any]
+)
+"""What ``messages=`` accepts: a typed message model or a plain mapping.
+
+The models are the recommended form — they give completion, field
+validation at construction, and self-documenting call sites. Mappings in
+the OpenAI wire shape (``{"role": "user", "content": "hi"}``) are accepted
+too, and are validated into the corresponding model before the request is
+built, so a mistyped role or a missing field still raises rather than
+reaching the API.
+
+Note that this is deliberately wider than ``ChatCompletionRequest.messages``,
+which stays model-only: that field is the validation boundary where mappings
+are coerced, so widening it there would let raw mappings through unvalidated.
+"""
 
 
 class ChatCompletionRequest(BaseModel):
@@ -352,6 +371,8 @@ __all__ = [
     "ToolMessage",
     "SystemMessage",
     "DeveloperMessage",
+    # Message unions
+    "ChatMessageParam",
     # Request model
     "ChatCompletionRequest",
 ]

--- a/tests/unit/resources/test_chat_message_mappings.py
+++ b/tests/unit/resources/test_chat_message_mappings.py
@@ -1,0 +1,298 @@
+"""Unit tests for plain-mapping message input on chat.completions.
+
+``messages=`` accepts either the typed message models or plain mappings in
+the OpenAI wire shape. Mappings are validated into the corresponding model
+before anything reads them, so the two forms are interchangeable and a
+malformed mapping still raises rather than reaching the API.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from venice_ai.resources.chat.completions import (
+    ChatCompletions,
+    _coerce_messages,
+)
+from venice_ai.types.api import (
+    AssistantMessage,
+    DeveloperMessage,
+    SystemMessage,
+    ToolMessage,
+    UserMessage,
+)
+from venice_ai.types.api.chat import (
+    ChatChoice,
+    ChatCompletionResponse,
+    ChatMessage,
+    ChatUsage,
+)
+from venice_ai.types.api.models import (
+    LLMModelPricing,
+    ModelResponse,
+    ModelsListResponse,
+    PricingTier,
+)
+
+_FAKE_CHAT_MODEL = "fake-chat-test-model"
+
+
+# ---------------------------------------------------------------------------
+# _coerce_messages
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceMessages:
+    @pytest.mark.parametrize(
+        ("mapping", "expected"),
+        [
+            ({"role": "user", "content": "hi"}, UserMessage),
+            ({"role": "system", "content": "sys"}, SystemMessage),
+            ({"role": "assistant", "content": "reply"}, AssistantMessage),
+            ({"role": "developer", "content": "dev"}, DeveloperMessage),
+            ({"role": "tool", "content": "result", "tool_call_id": "call_1"}, ToolMessage),
+        ],
+    )
+    def test_each_role_maps_to_its_model(self, mapping, expected):
+        (coerced,) = _coerce_messages([mapping])
+        assert isinstance(coerced, expected)
+        assert coerced.content == mapping["content"]
+
+    def test_model_instances_pass_through(self):
+        original = UserMessage(content="hi")
+        (coerced,) = _coerce_messages([original])
+        assert isinstance(coerced, UserMessage)
+        assert coerced.content == "hi"
+
+    def test_mixed_mappings_and_models(self):
+        coerced = _coerce_messages(
+            [{"role": "system", "content": "sys"}, UserMessage(content="hi")]
+        )
+        assert [type(m).__name__ for m in coerced] == ["SystemMessage", "UserMessage"]
+
+    def test_multimodal_mapping_content(self):
+        (coerced,) = _coerce_messages(
+            [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Describe this:"}],
+                }
+            ]
+        )
+        assert isinstance(coerced, UserMessage)
+        assert coerced.content[0].text == "Describe this:"
+
+    def test_empty_sequence(self):
+        assert _coerce_messages([]) == []
+
+    def test_caller_sequence_not_mutated(self):
+        original = [{"role": "user", "content": "hi"}]
+        _coerce_messages(original)
+        assert original == [{"role": "user", "content": "hi"}]
+
+    # -- validation is still enforced ---------------------------------------
+
+    def test_unknown_role_rejected(self):
+        with pytest.raises(ValidationError):
+            _coerce_messages([{"role": "wizard", "content": "hi"}])
+
+    def test_missing_content_rejected(self):
+        with pytest.raises(ValidationError):
+            _coerce_messages([{"role": "user"}])
+
+    def test_tool_message_missing_call_id_rejected(self):
+        with pytest.raises(ValidationError):
+            _coerce_messages([{"role": "tool", "content": "result"}])
+
+
+# ---------------------------------------------------------------------------
+# create()
+# ---------------------------------------------------------------------------
+
+
+class _MockClient:
+    def __init__(self):
+        self.post = AsyncMock(
+            return_value={
+                "id": "resp-1",
+                "object": "chat.completion",
+                "created": 1000000,
+                "model": _FAKE_CHAT_MODEL,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+        )
+
+
+@pytest.mark.asyncio
+class TestCreateAcceptsMappings:
+    async def test_mapping_and_model_produce_identical_body(self):
+        from_mapping = _MockClient()
+        await ChatCompletions(from_mapping).create(
+            model=_FAKE_CHAT_MODEL,
+            messages=[{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}],
+        )
+
+        from_model = _MockClient()
+        await ChatCompletions(from_model).create(
+            model=_FAKE_CHAT_MODEL,
+            messages=[SystemMessage(content="sys"), UserMessage(content="hi")],
+        )
+
+        assert from_mapping.post.call_args == from_model.post.call_args
+
+    async def test_invalid_mapping_raises_before_the_request(self):
+        client = _MockClient()
+        with pytest.raises(ValidationError):
+            await ChatCompletions(client).create(
+                model=_FAKE_CHAT_MODEL,
+                messages=[{"role": "wizard", "content": "hi"}],
+            )
+        client.post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# estimate_cost()
+# ---------------------------------------------------------------------------
+
+
+def _build_chat_with_pricing() -> ChatCompletions:
+    pricing = LLMModelPricing(
+        input=PricingTier(usd=1.0, diem=1.0),
+        output=PricingTier(usd=2.0, diem=2.0),
+        cache_input=None,
+    )
+    entry = ModelResponse.model_validate(
+        {
+            "id": _FAKE_CHAT_MODEL,
+            "object": "model",
+            "created": None,
+            "owned_by": "venice.ai",
+            "type": "text",
+            "model_spec": {
+                "name": _FAKE_CHAT_MODEL,
+                "availableContextTokens": 8192.0,
+                "pricing": pricing.model_dump(),
+            },
+        }
+    )
+    mock_client = MagicMock()
+    mock_client.models.list = AsyncMock(
+        return_value=ModelsListResponse(object="list", type="text", data=[entry])
+    )
+    return ChatCompletions(mock_client)
+
+
+@pytest.mark.asyncio
+class TestEstimateCostAcceptsMappings:
+    async def test_mapping_matches_model_estimate(self):
+        words = {"role": "user", "content": "one two three four five"}
+
+        from_mapping = await _build_chat_with_pricing().estimate_cost(
+            model=_FAKE_CHAT_MODEL, messages=[words]
+        )
+        from_model = await _build_chat_with_pricing().estimate_cost(
+            model=_FAKE_CHAT_MODEL, messages=[UserMessage(content=words["content"])]
+        )
+
+        assert from_mapping.prompt_tokens == from_model.prompt_tokens
+        assert from_mapping.total_cost_usd == from_model.total_cost_usd
+        assert from_mapping.prompt_tokens > 0
+
+
+# ---------------------------------------------------------------------------
+# run_with_tools()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestRunWithToolsAcceptsMappings:
+    async def test_history_is_normalized_to_models(self):
+        terminal = ChatCompletionResponse(
+            id="resp-terminal",
+            object="chat.completion",
+            created=1000000,
+            model=_FAKE_CHAT_MODEL,
+            choices=[
+                ChatChoice(
+                    index=0,
+                    message=ChatMessage(role="assistant", content="Final answer."),
+                    finish_reason="stop",
+                    stop_reason=None,
+                )
+            ],
+            usage=ChatUsage(
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+                prompt_tokens_details=None,
+            ),
+            prompt_logprobs=None,
+            venice_parameters=None,
+            service_tier=None,
+            system_fingerprint=None,
+            kv_transfer_params=None,
+        )
+
+        def a_tool() -> str:
+            """A tool the model never calls."""
+            return "unused"
+
+        chat = ChatCompletions(MagicMock())
+        chat.create = AsyncMock(return_value=terminal)  # type: ignore[method-assign]
+
+        result = await chat.run_with_tools(
+            model=_FAKE_CHAT_MODEL,
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[a_tool],
+        )
+
+        # The returned history must not leak the caller's raw mapping.
+        assert all(not isinstance(m, dict) for m in result.messages)
+        assert isinstance(result.messages[0], UserMessage)
+        assert result.messages[0].content == "hi"
+
+    async def test_caller_messages_not_mutated(self):
+        terminal = ChatCompletionResponse(
+            id="resp-terminal",
+            object="chat.completion",
+            created=1000000,
+            model=_FAKE_CHAT_MODEL,
+            choices=[
+                ChatChoice(
+                    index=0,
+                    message=ChatMessage(role="assistant", content="Final answer."),
+                    finish_reason="stop",
+                    stop_reason=None,
+                )
+            ],
+            usage=ChatUsage(
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+                prompt_tokens_details=None,
+            ),
+            prompt_logprobs=None,
+            venice_parameters=None,
+            service_tier=None,
+            system_fingerprint=None,
+            kv_transfer_params=None,
+        )
+
+        def a_tool() -> str:
+            """A tool the model never calls."""
+            return "unused"
+
+        chat = ChatCompletions(MagicMock())
+        chat.create = AsyncMock(return_value=terminal)  # type: ignore[method-assign]
+
+        messages = [{"role": "user", "content": "hi"}]
+        await chat.run_with_tools(model=_FAKE_CHAT_MODEL, messages=messages, tools=[a_tool])
+
+        assert messages == [{"role": "user", "content": "hi"}]

--- a/tests/unit/resources/test_chat_message_mappings.py
+++ b/tests/unit/resources/test_chat_message_mappings.py
@@ -11,12 +11,15 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pydantic import ValidationError
 
+from venice_ai.exceptions import InvalidRequestError
 from venice_ai.resources.chat.completions import (
     ChatCompletions,
     _coerce_messages,
+    _validate_e2ee_request,
 )
 from venice_ai.types.api import (
     AssistantMessage,
+    ChatCompletionRequest,
     DeveloperMessage,
     SystemMessage,
     ToolMessage,
@@ -104,6 +107,44 @@ class TestCoerceMessages:
     def test_tool_message_missing_call_id_rejected(self):
         with pytest.raises(ValidationError):
             _coerce_messages([{"role": "tool", "content": "result"}])
+
+    def test_unmodeled_field_handling_matches_the_request_model(self):
+        # Per-message fields the models don't declare are dropped, because the
+        # message models use pydantic's default extra="ignore". Only
+        # ChatCompletionRequest itself is extra="allow", and that governs
+        # top-level request fields. Coercing here must not diverge from
+        # handing the mapping straight to ChatCompletionRequest.
+        mapping = {"role": "user", "content": "hi", "some_future_field": 1}
+
+        (coerced,) = _coerce_messages([dict(mapping)])
+        via_request = ChatCompletionRequest(model=_FAKE_CHAT_MODEL, messages=[dict(mapping)])
+
+        assert coerced.model_dump() == via_request.messages[0].model_dump()
+
+
+class TestE2EEGuardSeesMappings:
+    """The E2EE pre-flight guard inspects the caller's raw sequence.
+
+    It must reject an E2EE-incompatible message whichever shape it arrives in,
+    since a mapping reaches the guard before any coercion happens.
+    """
+
+    def test_multimodal_mapping_rejected_under_e2ee(self):
+        with pytest.raises(InvalidRequestError, match="Multimodal"):
+            _validate_e2ee_request(
+                model="e2ee-fake-model",
+                messages=[{"role": "user", "content": [{"type": "text", "text": "describe"}]}],
+                tools=None,
+                venice_parameters=None,
+            )
+
+    def test_text_mapping_allowed_under_e2ee(self):
+        _validate_e2ee_request(
+            model="e2ee-fake-model",
+            messages=[{"role": "user", "content": "plain text"}],
+            tools=None,
+            venice_parameters=None,
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1.

## The problem

`messages=` was annotated as a union of the five message models, which is narrower than what the code actually accepts. Mappings in the OpenAI wire shape have always been validated and coerced by `ChatCompletionRequest`, but type checkers rejected them:

```
error: List item 0 has incompatible type "dict[str, str]"; expected
"UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage"  [list-item]
```

Reported against v1.3.0 in #1 and still reproducible on v2.0.0 (same symptom, renamed types).

## The fix

- New public `ChatMessageParam` union (`venice_ai.types`) — the five models plus `Mapping[str, Any]`. Applied to `create()`, `stream()`, `parse()`, `estimate_cost()`, and `run_with_tools()`.
- `ChatCompletionRequest.messages` stays **model-only** on purpose. It is the validation boundary where mappings get coerced; widening it there would let raw mappings through unvalidated and break `_concat_message_text`.
- `estimate_cost()` and `run_with_tools()` read the message list *before* it reaches the request model, so they now normalize at the boundary. Previously dict input would `AttributeError` on `.content` (`estimate_cost`) or leave raw dicts in the returned `ToolLoopResult.messages` (`run_with_tools`).

Accepting strictly more than before, so this is non-breaking → 2.0.1.

The typed models remain the documented idiom, and every example still uses them. `examples/best_practices/pydantic_models.py` previously said dicts "bypass all validation," which was never true — reworded to the accurate tradeoff (models fail at construction, mappings fail at call time).

## Verification

- `mypy src/` — clean, 171 files
- 18 new unit tests in `tests/unit/resources/test_chat_message_mappings.py` covering per-role coercion, mixed lists, multimodal mapping content, non-mutation of the caller's sequence, body equivalence between the two forms, and that malformed mappings still raise `ValidationError` *before* any request is sent
- 1202 existing tests pass across `tests/unit/resources/`, `tests/unit/type_defs/`, `tests/unit/tee/`, and the chat suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)