### PR TITLE
chore: correct the 2.0.1 date and generalize the checklist ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,8 +190,8 @@ website/docs/api/
 # Repo-internal brainstorming / specs / plans (not for the public repo)
 docs/superpowers/
 
-# Local v2.0.0 release working checklist (not committed)
-RELEASE_CHECKLIST_v2.0.0.md
+# Local per-release working checklists (not committed)
+RELEASE_CHECKLIST_v*.md
 
 # Local agent instructions and audit/scratch output (not for the public repo)
 CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.1] - 2026-08-12
+## [2.0.1] - 2026-08-13
 
 ### Fixed
 


### PR DESCRIPTION
Two small release-prep fixes ahead of cutting v2.0.1.

**CHANGELOG date.** The `[2.0.1]` heading carried `2026-08-12` — the same date as `[2.0.0]`, for a release that hasn't shipped. Corrected to `2026-08-13`. If the release is cut later than that, this needs bumping again.

**Checklist ignore.** `.gitignore` pinned the exact filename `RELEASE_CHECKLIST_v2.0.0.md`, so a per-release counterpart would show up as untracked and risk being swept into a `git add -A`. Replaced with the glob `RELEASE_CHECKLIST_v*.md`, which covers the existing file and future ones.

Verified both paths resolve to the new rule:

```
$ git check-ignore -v RELEASE_CHECKLIST_v2.0.0.md RELEASE_CHECKLIST_v2.0.1.md
.gitignore:194:RELEASE_CHECKLIST_v*.md	RELEASE_CHECKLIST_v2.0.0.md
.gitignore:194:RELEASE_CHECKLIST_v*.md	RELEASE_CHECKLIST_v2.0.1.md
```

No source changes — the 2.0.1 payload is unchanged from #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)