### PR TITLE
fix: correct broken Getting Started example and guard the install path (2.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2026-08-14
+
+### Fixed
+
+- **Getting Started example raised `TypeError`.** The first code sample in the documentation site's Getting Started page constructed a message positionally (`UserMessage("Hello, Venice!")`), which Pydantic rejects with `BaseModel.__init__() takes 1 positional argument but 2 were given`. The message models take keyword arguments only; the sample now reads `UserMessage(content="Hello, Venice!")`.
+- **Getting Started gave an installation sequence that could not work.** The Claude Code skills section instructed readers to run `venice skills install` after a plain `pip install venice-ai`. The `venice` CLI ships behind the optional `[cli]` extra, so that sequence fails on the install command. The section now installs `'venice-ai[cli]>=2'` first.
+
+### Changed
+
+- **Documented installation commands now carry a `>=2` version floor and are quoted.** On Python 3.12 and below, a bare `pip install venice-ai` resolves to v1.3.x silently — pip backtracks to the newest release whose `Requires-Python` matches, with no warning — so a reader following v2 documentation on an older interpreter would install v1 and hit confusing import errors. `pip install 'venice-ai>=2'` instead produces an explicit failure naming the cause (`Ignored the following versions that require a different python version: 2.0.2 Requires-Python >=3.13`). The specifiers are also quoted throughout because `[...]` is a glob in zsh, where an unquoted `pip install venice-ai[cli]` fails with `no matches found`. Applies to the README, the documentation site, and the bundled skills. To stay on v1, pin `venice-ai<2`.
+- **The Python 3.13 requirement is stated at the point of installation.** It previously appeared only in the README's Requirements section, several hundred lines below the Quick Start, and below the install block on the Getting Started page.
+
 ## [2.0.1] - 2026-08-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,14 +23,17 @@
 > **This is an unofficial, community-maintained SDK for Venice.ai.**
 > Not affiliated with or endorsed by Venice AI. For official resources visit [Venice.ai](https://venice.ai/).
 
-> **v2.0.0** — fully breaking rewrite over v1.3.x with enterprise-grade features. Review the [CHANGELOG](https://github.com/sethbang/venice-ai/blob/main/CHANGELOG.md) and the [Migration Guide](https://venice-docs.sbang.dev/docs/guides/migration/) before upgrading.
+> **v2.x** — fully breaking rewrite over v1.3.x with enterprise-grade features. Review the [release notes](https://github.com/sethbang/venice-ai/releases), the [CHANGELOG](https://github.com/sethbang/venice-ai/blob/main/CHANGELOG.md), and the [Migration Guide](https://venice-docs.sbang.dev/docs/guides/migration/) before upgrading.
 
 ---
 
 ## Quick Start
 
+> **Requires Python 3.13+.** On earlier versions `pip install venice-ai` resolves to v1.3.x
+> without an error. Pin the major version so you get a clear failure instead of the wrong SDK.
+
 ```bash
-pip install venice-ai
+pip install 'venice-ai>=2'
 export VENICE_API_KEY="your-api-key-here"
 ```
 
@@ -55,7 +58,7 @@ Migrating from v1.x? See the [Migration Guide](https://venice-docs.sbang.dev/doc
 ## Command Line Interface
 
 ```bash
-pip install venice-ai[cli]
+pip install 'venice-ai[cli]>=2'
 
 venice chat start                  # Interactive chat
 venice image generate "..."        # Image generation
@@ -451,17 +454,20 @@ print(f"Cost: ${cost['usd']:.4f}")
 
 ### Installation Options
 
+Quote the specifier — `[...]` is a glob in zsh, and the `>=2` floor turns an
+incompatible Python into a clear pip error instead of a silent v1.3.x install.
+
 ```bash
-pip install venice-ai            # Core
-pip install venice-ai[cli]       # CLI tools
-pip install venice-ai[redis]     # Redis backend
-pip install venice-ai[enterprise] # Enterprise (redis + prometheus + otel)
-pip install venice-ai[adaptive]  # Adaptive rate limiting
-pip install venice-ai[x402]      # x402 wallet auth (eth-account + siwe)
-pip install venice-ai[x402-solana] # x402 Solana USDC top-up (solders)
-pip install venice-ai[e2ee]      # TEE client-side E2EE (cryptography)
-pip install venice-ai[e2ee-verify] # Full client-side TDX quote verification (dcap-qvl)
-pip install venice-ai[all]       # Everything
+pip install 'venice-ai>=2'                # Core
+pip install 'venice-ai[cli]>=2'           # CLI tools
+pip install 'venice-ai[redis]>=2'         # Redis backend
+pip install 'venice-ai[enterprise]>=2'    # Enterprise (redis + prometheus + otel)
+pip install 'venice-ai[adaptive]>=2'      # Adaptive rate limiting
+pip install 'venice-ai[x402]>=2'          # x402 wallet auth (eth-account + siwe)
+pip install 'venice-ai[x402-solana]>=2'   # x402 Solana USDC top-up (solders)
+pip install 'venice-ai[e2ee]>=2'          # TEE client-side E2EE (cryptography)
+pip install 'venice-ai[e2ee-verify]>=2'   # Full client-side TDX quote verification (dcap-qvl)
+pip install 'venice-ai[all]>=2'           # Everything
 ```
 
 ### Client Setup
@@ -495,7 +501,7 @@ export VENICE_BACKEND__REDIS__REDIS_URL=redis://localhost:6379
 export VENICE_HTTP_CLIENT__TIMEOUT=60.0
 ```
 
-> **Note:** Env var auto-loading requires `pydantic-settings`: `pip install venice-ai[enterprise]`
+> **Note:** Env var auto-loading requires `pydantic-settings`: `pip install 'venice-ai[enterprise]>=2'`
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "venice-ai"
-version = "2.0.1"
+version = "2.0.2"
 description = "Unofficial, community-maintained Python client library for interacting with the Venice.ai API, offering comprehensive access to its features with unified architecture and intelligent rate limiting."
 readme = "README.md"
 license = "MIT"

--- a/src/venice_ai/__init__.py
+++ b/src/venice_ai/__init__.py
@@ -401,4 +401,4 @@ try:
 
     __version__ = _pkg_version("venice-ai")
 except Exception:  # pragma: no cover - source tree without installed metadata
-    __version__ = "2.0.1"
+    __version__ = "2.0.2"

--- a/src/venice_ai/auth/__init__.py
+++ b/src/venice_ai/auth/__init__.py
@@ -5,12 +5,12 @@ Exposes wallet-based auth for the ``/x402/*`` endpoints:
 * :class:`venice_ai.auth.x402.X402Auth` — EVM (EIP-4361 SIWE + EIP-3009)
   flow. Requires the ``x402`` extra::
 
-      pip install venice-ai[x402]
+      pip install 'venice-ai[x402]'
 
 * :class:`venice_ai.auth.x402_solana.SolanaX402Auth` — Solana ("exact"
   SVM settlement) flow. Requires the ``x402-solana`` extra::
 
-      pip install venice-ai[x402-solana]
+      pip install 'venice-ai[x402-solana]'
 
 Both names are imported lazily (PEP 562 ``__getattr__``) so that installing
 only one extra does not force the other's optional dependencies — importing

--- a/src/venice_ai/auth/x402.py
+++ b/src/venice_ai/auth/x402.py
@@ -13,7 +13,7 @@ Usage::
     # auth.wallet_address — checksummed address derived from the key
     # auth.build_header() — returns the base64 value for ``X-Sign-In-With-X``
 
-This module is optional and requires ``pip install venice-ai[x402]``.
+This module is optional and requires ``pip install 'venice-ai[x402]'``.
 """
 
 from __future__ import annotations

--- a/src/venice_ai/auth/x402_solana.py
+++ b/src/venice_ai/auth/x402_solana.py
@@ -38,7 +38,7 @@ Usage::
         token_program="Tokenkeg...",
     )
 
-This module is optional and requires ``pip install venice-ai[x402-solana]``.
+This module is optional and requires ``pip install 'venice-ai[x402-solana]'``.
 """
 
 from __future__ import annotations

--- a/src/venice_ai/core/config/enterprise.py
+++ b/src/venice_ai/core/config/enterprise.py
@@ -184,7 +184,7 @@ class SchedulerConfig(BaseModel):
 
     Enterprise feature: Only active when ``RateLimiterMode.ADAPTIVE`` is selected
     (``VeniceAIConfig.rate_limiter.mode = RateLimiterMode.ADAPTIVE``).
-    Requires: ``pip install venice-ai[adaptive]`` and a Redis backend.
+    Requires: ``pip install 'venice-ai[adaptive]'`` and a Redis backend.
 
     For basic SDK usage the default ``RateLimiterMode.SIMPLE`` mode does not use
     this scheduler at all — only ``HttpClientConfig`` is needed.

--- a/src/venice_ai/core/config/main.py
+++ b/src/venice_ai/core/config/main.py
@@ -88,7 +88,7 @@ class VeniceAIConfig(BaseSettings):
                 "pydantic-settings is not installed. VENICE_* environment variables "
                 "(e.g. VENICE_API_KEY) will NOT be read automatically. "
                 "Install it with: pip install pydantic-settings  "
-                "or: pip install venice-ai[enterprise]",
+                "or: pip install 'venice-ai[enterprise]'",
                 UserWarning,
                 stacklevel=3,
             )

--- a/src/venice_ai/factory.py
+++ b/src/venice_ai/factory.py
@@ -499,7 +499,7 @@ class VeniceClientFactory:
             except ImportError:
                 raise ImportError(
                     "adaptive-rate-limiter package is required for ADAPTIVE rate limiting mode. "
-                    "Install it with: pip install venice-ai[adaptive]"
+                    "Install it with: pip install 'venice-ai[adaptive]'"
                 ) from None
             except Exception as exc:
                 raise RuntimeError(

--- a/src/venice_ai/provider/classifier_adapter.py
+++ b/src/venice_ai/provider/classifier_adapter.py
@@ -66,7 +66,7 @@ class VeniceClassifierAdapter(ClassifierProtocol):
         if not _ADAPTIVE_AVAILABLE:
             raise ImportError(
                 "adaptive-rate-limiter package is required for VeniceClassifierAdapter. "
-                "Install with: pip install venice-ai[adaptive]"
+                "Install with: pip install 'venice-ai[adaptive]'"
             )
         self._classifier = classifier
 

--- a/src/venice_ai/provider/venice_provider.py
+++ b/src/venice_ai/provider/venice_provider.py
@@ -88,7 +88,7 @@ class VeniceProvider(ProviderInterface):
         if not _ADAPTIVE_AVAILABLE:
             raise ImportError(
                 "adaptive-rate-limiter package is required for VeniceProvider. "
-                "Install with: pip install venice-ai[adaptive]"
+                "Install with: pip install 'venice-ai[adaptive]'"
             )
         self._client = client
         self._discovery = rate_limit_discovery or (

--- a/src/venice_ai/rate_limiting/config.py
+++ b/src/venice_ai/rate_limiting/config.py
@@ -26,7 +26,7 @@ class RateLimiterConfig:
         - Proactive rate limiting (prevents 429s)
         - Multi-process/worker coordination via Redis
         - Token prediction and cold-start protection
-        - Requires: pip install venice-ai[adaptive]
+        - Requires: pip install 'venice-ai[adaptive]'
         - Requires: redis_url configuration
     """
 

--- a/src/venice_ai/skills/venice-ai-production/references/prompt-caching.md
+++ b/src/venice_ai/skills/venice-ai-production/references/prompt-caching.md
@@ -91,7 +91,7 @@ The cache works on **prefix matching** — if your messages list has the same fi
 
 For multi-turn conversations:
 ```
-[SystemMessage, UserMessage("Hi"), AssistantMessage("Hi back"), UserMessage("Q")]
+[SystemMessage(content=BIG_PROMPT), UserMessage(content="Hi"), AssistantMessage(content="Hi back"), UserMessage(content="Q")]
 ```
 The longest cacheable prefix is `[SystemMessage]` if the user message changes per call. Keep your stable-prefix content at the top of the messages list.
 

--- a/src/venice_ai/skills/venice-ai-production/references/rate-limiting.md
+++ b/src/venice_ai/skills/venice-ai-production/references/rate-limiting.md
@@ -82,7 +82,7 @@ For a complete retry helper covering rate-limit + timeout + connection errors, s
 
 ## Distributed: Redis-backed rate limiter
 
-For multi-instance deployments (multiple workers / pods talking to the same Venice account), in-memory throttling doesn't work — each worker has its own view of `remaining_requests`. The SDK coordinates limits across workers via Redis using the **adaptive** rate limiter, wired through the production config preset (requires `pip install venice-ai[adaptive]`):
+For multi-instance deployments (multiple workers / pods talking to the same Venice account), in-memory throttling doesn't work — each worker has its own view of `remaining_requests`. The SDK coordinates limits across workers via Redis using the **adaptive** rate limiter, wired through the production config preset (requires `pip install 'venice-ai[adaptive]>=2'`):
 
 ```python
 import os

--- a/src/venice_ai/skills/venice-ai/references/migration-v1-to-v2.md
+++ b/src/venice_ai/skills/venice-ai/references/migration-v1-to-v2.md
@@ -27,9 +27,12 @@ async with VeniceClient() as client:
 | Concern | v1.3.x | v2 |
 |---|---|---|
 | Python | ≥3.11 | **≥3.13** |
-| Install | `pip install venice-ai` | same; optional extras `[x402]`, `[redis]`, `[adaptive]`, `[e2ee]` |
+| Install | `pip install venice-ai` | `pip install 'venice-ai>=2'`; optional extras `[x402]`, `[redis]`, `[adaptive]`, `[e2ee]` |
 
-If you're stuck on Python ≤3.12, stay on the latest v1 release.
+Keep the `>=2` floor: on Python ≤3.12 a bare `pip install venice-ai` resolves to v1.3.x
+with no error, so the floor is what turns a wrong-version install into a clear pip failure.
+
+If you're stuck on Python ≤3.12, stay on the latest v1 release by pinning `venice-ai<2`.
 
 ## 3. Renamed methods
 

--- a/tests/unit/test_factory_rate_limiter.py
+++ b/tests/unit/test_factory_rate_limiter.py
@@ -99,7 +99,7 @@ class TestAdaptiveFallbackWithoutPackage:
 
             # Should raise with informative message
             assert "adaptive-rate-limiter" in str(exc_info.value)
-            assert "pip install venice-ai[adaptive]" in str(exc_info.value)
+            assert "pip install 'venice-ai[adaptive]'" in str(exc_info.value)
 
     def test_adaptive_fallback_warning_message(self):
         """Adaptive mode raises ImportError with install instructions (strict mode)."""
@@ -131,7 +131,7 @@ class TestAdaptiveFallbackWithoutPackage:
             # Error message should contain install instructions
             error_msg = str(exc_info.value)
             assert "adaptive-rate-limiter" in error_msg
-            assert "pip install venice-ai[adaptive]" in error_msg
+            assert "pip install 'venice-ai[adaptive]'" in error_msg
 
 
 class TestAdaptiveRequiresRedisUrl:

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -12,12 +12,13 @@ The Venice AI Python SDK is a production-ready, fully-typed async client for [Ve
 
 ## Install
 
+**Python 3.13+ is required.** On earlier versions `pip install venice-ai` resolves to
+v1.3.x without an error, so pin the major version to get a clear failure instead:
+
 ```bash
-pip install venice-ai
+pip install 'venice-ai>=2'
 export VENICE_API_KEY="your-api-key-here"
 ```
-
-Python 3.13+ is required.
 
 ## Your first chat completion
 
@@ -32,7 +33,7 @@ async def main() -> None:
         model = await client.models.resolve_chat()
         response = await client.chat.completions.create(
             model=model,
-            messages=[UserMessage("Hello, Venice!")],
+            messages=[UserMessage(content="Hello, Venice!")],
         )
         print(response.text)
 
@@ -44,9 +45,11 @@ Prefer a synchronous client? Use `SyncVeniceClient` with a plain `with` block.
 ## Claude Code skills
 
 The SDK bundles four Claude Code skills (chat, multimodal, production, x402).
-After `pip install venice-ai`, install them into your project:
+Installing them uses the `venice` CLI, which ships as an optional extra:
 
 ```bash
+pip install 'venice-ai[cli]>=2'
+
 venice skills install            # → ./.claude/skills/
 venice skills install --global   # → ~/.claude/skills/
 venice skills list               # show bundled skills + install state

--- a/website/docs/guides/advanced.md
+++ b/website/docs/guides/advanced.md
@@ -12,7 +12,7 @@ via `RateLimiterMode`:
   (`min_backoff`/`max_backoff`, `max_retries`, failure-window circuit breaking).
   Single-process; no Redis.
 - **`ADAPTIVE`** — **proactive** (prevents `429`s) with multi-worker coordination
-  via Redis. Requires `pip install venice-ai[adaptive]` and a `redis_url`.
+  via Redis. Requires `pip install 'venice-ai[adaptive]>=2'` and a `redis_url`.
 - **`DISABLED`** — no rate limiting (testing only; not recommended in production).
 
 **Configuration** (set on the client config's `rate_limiter` field):

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -11,14 +11,17 @@ Command-line interface for Venice AI. Chat with AI models, generate images, crea
 
 ### Install with pip
 
+Requires Python 3.13+. Quote the specifier — `[...]` is a glob in zsh — and keep the
+`>=2` floor so an older Python fails loudly instead of installing v1.3.x.
+
 ```bash
-pip install venice-ai[cli]
+pip install 'venice-ai[cli]>=2'
 ```
 
 ### Install with Poetry
 
 ```bash
-poetry add venice-ai[cli]
+poetry add 'venice-ai[cli]>=2'
 ```
 
 ### Development Install
@@ -1397,7 +1400,7 @@ venice configure
 ### Module Not Found
 
 ```bash
-pip install venice-ai[cli]
+pip install 'venice-ai[cli]>=2'
 ```
 
 ### Command Not Found

--- a/website/docs/guides/migration.md
+++ b/website/docs/guides/migration.md
@@ -10,6 +10,39 @@ rough order of impact. For the complete list of additions, see the
 
 ---
 
+## 0. Raise your Python floor first, in your dependency file
+
+v2 requires **Python 3.13+**. On anything older, pip resolves `venice-ai` to the newest
+v1 release *silently* — no error, no warning — so the first sign of trouble is an
+`ImportError` on a v2 name.
+
+Pin the major version everywhere the dependency is declared, not just in the command you
+type. A bare `venice-ai` in `requirements.txt` or `pyproject.toml` is the common way to
+end up back on v1 without noticing:
+
+```text
+# requirements.txt
+venice-ai>=2
+```
+
+```toml
+# pyproject.toml
+dependencies = ["venice-ai>=2"]
+```
+
+With the floor in place, an interpreter that is too old fails loudly and says why:
+
+```console
+$ pip install 'venice-ai>=2'
+ERROR: Ignored the following versions that require a different python version:
+       2.0.2 Requires-Python <4.0,>=3.13
+ERROR: No matching distribution found for venice-ai>=2
+```
+
+Staying on v1 for now is a legitimate choice — pin `venice-ai<2` to make it explicit.
+
+---
+
 ## 1. The client is now async by default
 
 This is the largest change. In v1, `VeniceClient` was **synchronous** and a separate

--- a/website/docs/guides/rate-limiting-architecture.md
+++ b/website/docs/guides/rate-limiting-architecture.md
@@ -45,7 +45,7 @@ resolves nothing to buckets.
 The reactive limiter above is the default. For multi-process / multi-worker
 deployments, the SDK can swap it for the proactive `AdaptiveScheduler` that
 ships in the standalone **`adaptive-rate-limiter`** PyPI package
-(`pip install venice-ai[adaptive]`). When `RateLimiterMode.ADAPTIVE` is
+(`pip install 'venice-ai[adaptive]>=2'`). When `RateLimiterMode.ADAPTIVE` is
 configured, `factory._create_rate_limiter` constructs an `AdaptiveScheduler`
 backed by Redis, wraps it in `AdaptiveSchedulerAdapter` (in `factory.py`)
 to satisfy `RateLimiterProtocol`, and returns it in place of


### PR DESCRIPTION
## Why

Two defects found while pre-flighting the v2 release, plus the install-path hazard behind them.

### 1. The first code example on the docs site crashes

```python
messages=[UserMessage("Hello, Venice!")]   # website/docs/getting-started.md
# TypeError: BaseModel.__init__() takes 1 positional argument but 2 were given
```

The message models are keyword-only. The README gets this right; the docs site did not. Swept the repo — this was the only live instance.

### 2. The docs site gave an install sequence that cannot work

> After `pip install venice-ai`, install them into your project: `venice skills install`

The `venice` CLI ships behind the `[cli]` extra, so that sequence fails on the install command — for the bundled-skills feature specifically.

### 3. `pip install venice-ai` silently gives v1 on Python ≤3.12

```
$ python3.12 -m pip install --dry-run venice-ai
Would install venice-ai-1.3.0          # no warning, no error

$ python3.12 -m pip install --dry-run 'venice-ai>=2'
ERROR: Ignored the following versions that require a different python version:
       2.0.1 Requires-Python <4.0,>=3.13
ERROR: No matching distribution found for venice-ai>=2
```

pip backtracks to the newest release whose `Requires-Python` matches, silently. A reader following v2 docs on 3.12 installed v1 and hit confusing `ImportError`s far from the cause. A `>=2` floor makes pip state the real reason. `Requires-Python` metadata is unchanged and stays honest — to stay on v1, pin `venice-ai<2`.

### 4. Unquoted extras are broken in zsh

`pip install venice-ai[cli]` fails with `zsh: no matches found` on the macOS default shell. Every documented specifier is now quoted, including the runtime error hints and docstrings that feed the API reference.

## Changes

- Fix the `TypeError` in the Getting Started sample; fix its skills install sequence
- Add a `>=2` floor and quote every documented install command (README, docs site, bundled skills)
- Quote extras in runtime error hints and docstrings; update the two tests pinning those strings
- State the Python 3.13 requirement at the point of installation instead of ~540 lines below it
- Bump to 2.0.2 (`pyproject.toml` + `__init__.py` fallback) with a CHANGELOG entry

## Verification

| Check | Result |
|---|---|
| `pytest tests/unit/test_factory_rate_limiter.py tests/cli/test_missing_cli_extra_hint.py` | 27 passed |
| `make skills-check` | size, example paths, code-block lint, SDK symbols — all pass |
| `make lint` / `make format-check` | all checks passed, 436 files formatted |
| `poetry build` | `venice_ai-2.0.2`, `Requires-Python >=3.13,<4.0`, 32 skill files in wheel |
| Corrected examples executed against published 2.0.1 | both construct successfully |
| Built wheel METADATA | 3.13 gate renders at Quick Start; zero bare `pip install venice-ai` commands |

Full suite not run here — that's yours.

Note: the PyPI project page renders the README baked into the published artifact, so these README fixes only reach PyPI when 2.0.2 ships. The docs-site fixes deploy independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)