### PR TITLE
fix: rename CLI command to venice-py to stop shadowing the official Venice CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-08-14
+
+### Changed
+
+- **The CLI command is now `venice-py`, renamed from `venice`.** Venice's official CLI ([`veniceai-cli`](https://www.npmjs.com/package/veniceai-cli), published March 2026) installs a binary named `venice`, and so did this SDK's `[cli]` extra as of v2.0.0. With both installed, which one ran depended on `PATH` order — typically this SDK's inside an activated virtualenv and Venice's outside it. Because the two share subcommand names (`chat`, `image`, `video`, `embeddings`, `models`, `characters`), the wrong tool would run and reject the flags rather than report the collision. The two are unrelated programs and no longer contend for the name.
+
+  Update any scripts, aliases, and CI steps that invoke `venice`:
+
+  ```bash
+  venice chat start        # before
+  venice-py chat start     # after
+  ```
+
+  Shell completions must be regenerated, and their environment variable is now `_VENICE_PY_COMPLETE`:
+
+  ```bash
+  venice-py completion zsh >> ~/.zshrc
+  ```
+
+  Upgrading in place does not remove the old script. If `venice --version` still reports a Venice **AI CLI** banner after upgrading, a stale entry point is left over from the v2.0.x install — delete it from the environment's `bin/` directory (`rm "$(command -v venice)"` while that environment is active), or the collision persists.
+
+  This SDK is unofficial and community-maintained. For Venice's official CLI, see [veniceai/venice-cli](https://github.com/veniceai/venice-cli).
+
 ## [2.0.2] - 2026-08-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -57,16 +57,21 @@ Migrating from v1.x? See the [Migration Guide](https://venice-docs.sbang.dev/doc
 
 ## Command Line Interface
 
+The command is `venice-py`. It is not Venice's official CLI — that one is
+[`veniceai-cli`](https://github.com/veniceai/venice-cli), a separate Node program invoked
+as `venice`. Both can be installed at once. (This command was `venice` in v2.0.x; see the
+[CHANGELOG](CHANGELOG.md) if you are upgrading.)
+
 ```bash
 pip install 'venice-ai[cli]>=2'
 
-venice chat start                  # Interactive chat
-venice image generate "..."        # Image generation
-venice image multi-edit -p "..."   # Multi-image edit
-venice models                      # Browse models
-venice characters reviews <slug>   # Character reviews
-venice account keys rate-limits    # Per-model RPM/TPM limits
-venice configure                   # Setup wizard
+venice-py chat start                  # Interactive chat
+venice-py image generate "..."        # Image generation
+venice-py image multi-edit -p "..."   # Multi-image edit
+venice-py models                      # Browse models
+venice-py characters reviews <slug>   # Character reviews
+venice-py account keys rate-limits    # Per-model RPM/TPM limits
+venice-py configure                   # Setup wizard
 ```
 
 Features: streaming chat with 6 animation modes, image generation with 11+ parameters, model discovery, rich terminal UI. See the [CLI Reference](https://venice-docs.sbang.dev/docs/guides/cli/) for full CLI documentation.
@@ -75,12 +80,12 @@ Features: streaming chat with 6 animation modes, image generation with 11+ param
 
 ## Build with Claude Code
 
-Four [Claude Code skills](https://docs.claude.com/en/docs/claude-code/skills) ship with the SDK. Install them into the current project with `venice skills install` (or `venice skills install --global` for `~/.claude/skills/`); list them with `venice skills list`. They auto-load when their trigger contexts match — `venice chat`, `venice image`, `venice rate limit`, `venice x402` — and steer Claude toward idiomatic v2 code (dynamic model resolution, `async with stream:`, `run_with_tools`, `client.gather(max_concurrency=N)`, `top_up_with`, etc.) instead of OpenAI-style or v1 patterns.
+Four [Claude Code skills](https://docs.claude.com/en/docs/claude-code/skills) ship with the SDK. Install them into the current project with `venice-py skills install` (or `venice-py skills install --global` for `~/.claude/skills/`); list them with `venice-py skills list`. They auto-load when their trigger contexts match — `venice-py chat`, `venice-py image`, `venice rate limit`, `venice x402` — and steer Claude toward idiomatic v2 code (dynamic model resolution, `async with stream:`, `run_with_tools`, `client.gather(max_concurrency=N)`, `top_up_with`, etc.) instead of OpenAI-style or v1 patterns.
 
 ```bash
-venice skills install            # → ./.claude/skills/
-venice skills install --global   # → ~/.claude/skills/
-venice skills list               # show bundled skills + install state
+venice-py skills install            # → ./.claude/skills/
+venice-py skills install --global   # → ~/.claude/skills/
+venice-py skills list               # show bundled skills + install state
 ```
 
 Catalog: `venice-ai` (chat / streaming / tools / structured output), `venice-ai-multimodal` (image / audio / video / music), `venice-ai-production` (retries / rate limits / cost tracking / observability), `venice-ai-x402` (wallet auth / SIWE / on-chain top-up). See [`tools/skills/README.md`](https://github.com/sethbang/venice-ai/blob/main/tools/skills/README.md) for the full catalog and validation tooling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "venice-ai"
-version = "2.0.2"
+version = "2.1.0"
 description = "Unofficial, community-maintained Python client library for interacting with the Venice.ai API, offering comprehensive access to its features with unified architecture and intelligent rate limiting."
 readme = "README.md"
 license = "MIT"
@@ -38,7 +38,7 @@ classifiers = [
 ]
 packages = [{ include = "venice_ai", from = "src" }]
 # skills/*/evals holds held-out calibration sets for the bundled skills. They are
-# authoring-time material, never read at runtime (`venice skills install` filters
+# authoring-time material, never read at runtime (`venice-py skills install` filters
 # them out), and publishing them would leak the test set into every install.
 exclude = ["src/venice_ai/test_support", "src/venice_ai/skills/*/evals"]
 
@@ -350,4 +350,4 @@ exclude = [
 ]
 
 [tool.poetry.scripts]
-venice = "venice_ai.cli:cli"
+venice-py = "venice_ai.cli:cli"

--- a/src/venice_ai/__init__.py
+++ b/src/venice_ai/__init__.py
@@ -401,4 +401,4 @@ try:
 
     __version__ = _pkg_version("venice-ai")
 except Exception:  # pragma: no cover - source tree without installed metadata
-    __version__ = "2.0.2"
+    __version__ = "2.1.0"

--- a/src/venice_ai/cli/_model_defaults.py
+++ b/src/venice_ai/cli/_model_defaults.py
@@ -1,7 +1,7 @@
 """Runtime resolution of default models for the CLI.
 
 The CLI hardcodes NO model IDs. When the user has not explicitly chosen a
-model (via a flag or via a saved value in ``venice configure``), the model is
+model (via a flag or via a saved value in ``venice-py configure``), the model is
 resolved from the live Venice ``/models`` API at call time, so newly added and
 deprecated models are picked up automatically without code changes.
 """
@@ -61,6 +61,6 @@ async def resolve_default_model(
         raise click.ClickException(
             f"Could not resolve a default {kind} model from the Venice API "
             f"({exc}). Pass an explicit model with --model, or run "
-            f"'venice configure' while online."
+            f"'venice-py configure' while online."
         ) from exc
     return resolved

--- a/src/venice_ai/cli/cli.py
+++ b/src/venice_ai/cli/cli.py
@@ -25,7 +25,7 @@ from .commands.models.group import models as models_group
 from .config import load_config, set_active_config_path
 from .utils.console import console, enable_plain_mode, print_version_info
 
-# Top-level command grouping for the curated ``venice --help`` layout.
+# Top-level command grouping for the curated ``venice-py --help`` layout.
 # The CLI ships ~13 subcommands; lumping them in one alphabetical block was
 # making the help output a wall of names, so we group them by intent.
 _COMMAND_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
@@ -75,8 +75,8 @@ def cli(ctx: click.Context, version: bool, config: str | None, plain: bool) -> N
     """
     Venice AI CLI - Your AI assistant in the terminal.
 
-    Featured commands: ``venice models resolve`` (find a model by capability),
-    ``venice lint`` (catch v1 / OpenAI-style usage in your code).
+    Featured commands: ``venice-py models resolve`` (find a model by capability),
+    ``venice-py lint`` (catch v1 / OpenAI-style usage in your code).
     """
     # Enable plain mode first if requested (before any output)
     if plain:
@@ -135,16 +135,16 @@ def completion(ctx: click.Context, shell: str) -> None:
 
     Examples:
 
-        venice completion bash >> ~/.bashrc
+        venice-py completion bash >> ~/.bashrc
 
-        venice completion zsh >> ~/.zshrc
+        venice-py completion zsh >> ~/.zshrc
 
-        venice completion fish > ~/.config/fish/completions/venice.fish
+        venice-py completion fish > ~/.config/fish/completions/venice-py.fish
     """
     from click.shell_completion import BashComplete, FishComplete, ZshComplete
 
-    prog_name = "venice"
-    complete_var = f"_{prog_name.upper()}_COMPLETE"
+    prog_name = "venice-py"
+    complete_var = f"_{prog_name.replace('-', '_').upper()}_COMPLETE"
 
     shell_map = {
         "bash": BashComplete,

--- a/src/venice_ai/cli/commands/account.py
+++ b/src/venice_ai/cli/commands/account.py
@@ -28,9 +28,9 @@ def balance(ctx, output_json):
 
     Examples:
 
-      venice account balance
+      venice-py account balance
 
-      venice account balance --json
+      venice-py account balance --json
     """
     asyncio.run(_balance_async(ctx, output_json))
 
@@ -127,15 +127,15 @@ def usage(ctx, output_json, start_date, end_date, currency):
 
     Examples:
 
-      venice account usage
+      venice-py account usage
 
-      venice account usage --start-date 2025-01-01 --end-date 2025-02-01
+      venice-py account usage --start-date 2025-01-01 --end-date 2025-02-01
 
-      venice account usage --currency USD
+      venice-py account usage --currency USD
 
-      venice account usage --json
+      venice-py account usage --json
 
-      venice account usage --start-date 2025-01-01 --json
+      venice-py account usage --start-date 2025-01-01 --json
     """
     asyncio.run(_usage_async(ctx, output_json, start_date, end_date, currency))
 
@@ -369,7 +369,7 @@ async def _usage_async(ctx, output_json, start_date, end_date, currency=None):
 
 
 # ---------------------------------------------------------------------------
-# `venice account keys ...` — single-key retrieve + update.
+# `venice-py account keys ...` — single-key retrieve + update.
 # `account list/create/delete` already live under the top-level `api-keys`
 # group; this subgroup adds the missing single-key surface (retrieve/update)
 # while keeping the `api-keys` group intact for backward compatibility.
@@ -380,7 +380,7 @@ async def _usage_async(ctx, output_json, start_date, end_date, currency=None):
 def keys():
     """Inspect and update individual API keys.
 
-    See ``venice api-keys`` for list/create/delete.
+    See ``venice-py api-keys`` for list/create/delete.
     """
     pass
 
@@ -394,8 +394,8 @@ def keys_get(ctx, api_key_id, output_json):
 
     Examples:
 
-      venice account keys get key_abc123
-      venice account keys get key_abc123 --json
+      venice-py account keys get key_abc123
+      venice-py account keys get key_abc123 --json
     """
     asyncio.run(_keys_get_async(ctx, api_key_id, output_json))
 
@@ -469,10 +469,10 @@ def keys_update(
 
     Examples:
 
-      venice account keys update key_abc123 --description "Production"
-      venice account keys update key_abc123 --expiry 2026-12-31
-      venice account keys update key_abc123 --limit-usd 50 --limit-diem 5
-      venice account keys update key_abc123 --limit-period MONTH
+      venice-py account keys update key_abc123 --description "Production"
+      venice-py account keys update key_abc123 --expiry 2026-12-31
+      venice-py account keys update key_abc123 --limit-usd 50 --limit-diem 5
+      venice-py account keys update key_abc123 --limit-period MONTH
     """
     # ``--limit-vcu`` is the legacy alias for ``--limit-diem``; the request
     # model (ConsumptionLimit) has no ``vcu`` field, so fold it into ``diem``
@@ -620,7 +620,7 @@ def _render_api_key(api_key_obj, *, plain: bool, output_json: bool, title: str) 
 
 
 # ---------------------------------------------------------------------------
-# `venice account keys rate-limits` / `rate-limit-logs` — surface
+# `venice-py account keys rate-limits` / `rate-limit-logs` — surface
 # client.api_keys.get_rate_limits() and get_rate_limit_logs().
 # ---------------------------------------------------------------------------
 
@@ -642,8 +642,8 @@ def keys_rate_limits(ctx, output_json):
 
     Examples:
 
-      venice account keys rate-limits
-      venice account keys rate-limits --json
+      venice-py account keys rate-limits
+      venice-py account keys rate-limits --json
     """
     asyncio.run(_keys_rate_limits_async(ctx, output_json))
 
@@ -734,8 +734,8 @@ def keys_rate_limit_logs(ctx, output_json):
 
     Examples:
 
-      venice account keys rate-limit-logs
-      venice account keys rate-limit-logs --json
+      venice-py account keys rate-limit-logs
+      venice-py account keys rate-limit-logs --json
     """
     asyncio.run(_keys_rate_limit_logs_async(ctx, output_json))
 

--- a/src/venice_ai/cli/commands/api_keys.py
+++ b/src/venice_ai/cli/commands/api_keys.py
@@ -31,9 +31,9 @@ def list_keys(ctx, output_json):
 
     Examples:
 
-      venice api-keys list
+      venice-py api-keys list
 
-      venice api-keys list --json
+      venice-py api-keys list --json
     """
     asyncio.run(_list_keys_async(ctx, output_json))
 
@@ -196,13 +196,13 @@ def create_key(
 
     Examples:
 
-      venice api-keys create --name "Production Key"
+      venice-py api-keys create --name "Production Key"
 
-      venice api-keys create --name "Admin" --type ADMIN
+      venice-py api-keys create --name "Admin" --type ADMIN
 
-      venice api-keys create --name "Capped" --limit-usd 50 --limit-period MONTH
+      venice-py api-keys create --name "Capped" --limit-usd 50 --limit-period MONTH
 
-      venice api-keys create --name "My App" --json
+      venice-py api-keys create --name "My App" --json
     """
     asyncio.run(
         _create_key_async(
@@ -320,9 +320,9 @@ def delete_key(ctx, key_id, yes):
 
     Examples:
 
-      venice api-keys delete key_abc123
+      venice-py api-keys delete key_abc123
 
-      venice api-keys delete key_abc123 --yes
+      venice-py api-keys delete key_abc123 --yes
     """
     asyncio.run(_delete_key_async(ctx, key_id, yes))
 

--- a/src/venice_ai/cli/commands/audio.py
+++ b/src/venice_ai/cli/commands/audio.py
@@ -43,10 +43,10 @@ def speak(ctx, text, model, voice, audio_format, speed, output, save_dir):
     """Convert text to speech.
 
     Examples:
-        venice audio speak "Hello, world!"
-        venice audio speak "Welcome to Venice" --voice af_heart --format wav
-        venice audio speak --model <tts-model> --output greeting.mp3 "Hi there"
-        echo "Some text" | venice audio speak
+        venice-py audio speak "Hello, world!"
+        venice-py audio speak "Welcome to Venice" --voice af_heart --format wav
+        venice-py audio speak --model <tts-model> --output greeting.mp3 "Hi there"
+        echo "Some text" | venice-py audio speak
     """
     asyncio.run(_speak_async(ctx, text, model, voice, audio_format, speed, output, save_dir))
 
@@ -132,10 +132,10 @@ def transcribe(ctx, file, model, language, timestamps, output_format, output):
     """Transcribe audio to text.
 
     Examples:
-        venice audio transcribe recording.mp3
-        venice audio transcribe meeting.wav --model <stt-model>
-        venice audio transcribe audio.mp3 --language en --timestamps
-        venice audio transcribe audio.mp3 --output transcript.txt
+        venice-py audio transcribe recording.mp3
+        venice-py audio transcribe meeting.wav --model <stt-model>
+        venice-py audio transcribe audio.mp3 --language en --timestamps
+        venice-py audio transcribe audio.mp3 --output transcript.txt
     """
     asyncio.run(_transcribe_async(ctx, file, model, language, timestamps, output_format, output))
 
@@ -235,10 +235,10 @@ def voices(ctx, model_id, gender, region_code, output_json):
 
     Examples:
 
-      venice audio voices
-      venice audio voices --gender female
-      venice audio voices --region af --json
-      venice audio voices --model tts-kokoro
+      venice-py audio voices
+      venice-py audio voices --gender female
+      venice-py audio voices --region af --json
+      venice-py audio voices --model tts-kokoro
     """
     asyncio.run(_voices_async(ctx, model_id, gender, region_code, output_json))
 

--- a/src/venice_ai/cli/commands/characters.py
+++ b/src/venice_ai/cli/commands/characters.py
@@ -85,12 +85,12 @@ def list_characters(
     """List available AI characters.
 
     Examples:
-        venice characters list
-        venice characters list --search coding
-        venice characters list --sort-by highlyRated --limit 20
-        venice characters list --tags philosophy --web-enabled
-        venice characters list --categories education
-        venice characters list --json
+        venice-py characters list
+        venice-py characters list --search coding
+        venice-py characters list --sort-by highlyRated --limit 20
+        venice-py characters list --tags philosophy --web-enabled
+        venice-py characters list --categories education
+        venice-py characters list --json
     """
     asyncio.run(
         _list_characters_async(
@@ -205,8 +205,8 @@ def info_character(ctx, slug, output_json):
     """Show detailed information about a character.
 
     Examples:
-        venice characters info alan-watts
-        venice characters info alan-watts --json
+        venice-py characters info alan-watts
+        venice-py characters info alan-watts --json
     """
     asyncio.run(_info_character_async(ctx, slug, output_json))
 
@@ -314,9 +314,9 @@ def reviews_character(ctx, slug, output_json, page, page_size):
     """Show public reviews for a character.
 
     Examples:
-        venice characters reviews alan-watts
-        venice characters reviews alan-watts --page 2 --page-size 50
-        venice characters reviews alan-watts --json
+        venice-py characters reviews alan-watts
+        venice-py characters reviews alan-watts --page 2 --page-size 50
+        venice-py characters reviews alan-watts --json
     """
     asyncio.run(_reviews_character_async(ctx, slug, output_json, page, page_size))
 

--- a/src/venice_ai/cli/commands/chat.py
+++ b/src/venice_ai/cli/commands/chat.py
@@ -186,7 +186,7 @@ async def _make_nonstreaming_request(
 def chat(ctx: click.Context):
     """Chat with AI models.
 
-    Use 'venice chat start' to begin a chat session or send a single message.
+    Use 'venice-py chat start' to begin a chat session or send a single message.
     """
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
@@ -328,13 +328,13 @@ def start_chat(
     Examples:
 
         # Quick message with word animation
-        venice chat start -a word "Tell me a joke"
+        venice-py chat start -a word "Tell me a joke"
 
         # Interactive session with typewriter effect
-        venice chat start --animation typewriter --animation-speed 0.05
+        venice-py chat start --animation typewriter --animation-speed 0.05
 
         # Fast streaming with stats
-        venice chat start --animation none --show-stats
+        venice-py chat start --animation none --show-stats
     """
     # Build venice_parameters dict from Venice-specific options.
     # NB: reasoning_effort is a top-level API field, not a member of
@@ -985,13 +985,13 @@ def chat_history(ctx: click.Context, json_output: bool, delete_id: str | None) -
     Examples:
 
         # List all saved conversations
-        venice chat history
+        venice-py chat history
 
         # Output as JSON
-        venice chat history --json
+        venice-py chat history --json
 
         # Delete a saved conversation
-        venice chat history --delete <id>
+        venice-py chat history --delete <id>
     """
     plain = ctx.obj.get("plain", False) if ctx.obj else False
 
@@ -1046,5 +1046,5 @@ def chat_history(ctx: click.Context, json_output: bool, delete_id: str | None) -
 
         console.print(table)
         console.print(
-            "\n[dim]Use [bold]venice chat start --continue-from <id>[/bold] to resume a conversation.[/dim]"
+            "\n[dim]Use [bold]venice-py chat start --continue-from <id>[/bold] to resume a conversation.[/dim]"
         )

--- a/src/venice_ai/cli/commands/configure.py
+++ b/src/venice_ai/cli/commands/configure.py
@@ -119,7 +119,7 @@ def configure_cli(ctx: dict[str, Any]) -> None:
                 print_error(
                     f"Could not fetch {label} models from the API. Skipping "
                     f"{label}-model selection — the CLI will auto-resolve one at "
-                    "runtime. Re-run 'venice configure' while online to pin one."
+                    "runtime. Re-run 'venice-py configure' while online to pin one."
                 )
                 continue
 
@@ -222,4 +222,4 @@ def configure_cli(ctx: dict[str, Any]) -> None:
 
     # Final message
     console.print("\n[bold green]Configuration complete![/bold green]")
-    print_info("You can now use 'venice chat' or 'venice image generate' commands")
+    print_info("You can now use 'venice-py chat' or 'venice-py image generate' commands")

--- a/src/venice_ai/cli/commands/embeddings.py
+++ b/src/venice_ai/cli/commands/embeddings.py
@@ -51,19 +51,19 @@ def embeddings(ctx, text, model, encoding_format, dimensions, output_json, outpu
     Examples:
 
       # Generate embeddings for text
-      venice embeddings "The quick brown fox"
+      venice-py embeddings "The quick brown fox"
 
       # Use a specific model
-      venice embeddings "Hello world" --model <embedding-model>
+      venice-py embeddings "Hello world" --model <embedding-model>
 
       # Output full JSON embedding vector
-      venice embeddings "Some text" --json
+      venice-py embeddings "Some text" --json
 
       # Save embeddings to file
-      venice embeddings "Some text" --output embeddings.json
+      venice-py embeddings "Some text" --output embeddings.json
 
       # Pipe text via stdin
-      echo "Some text" | venice embeddings
+      echo "Some text" | venice-py embeddings
     """
     asyncio.run(
         _embeddings_async(ctx, text, model, encoding_format, dimensions, output_json, output)

--- a/src/venice_ai/cli/commands/health.py
+++ b/src/venice_ai/cli/commands/health.py
@@ -1,4 +1,4 @@
-"""``venice health`` — connectivity + balance diagnostic.
+"""``venice-py health`` — connectivity + balance diagnostic.
 
 Quick check that the SDK can reach Venice, the API key is valid, the model
 catalog is accessible, and (optionally) a tiny embedding ping succeeds and
@@ -86,9 +86,9 @@ def health_command(
 
     Examples::
 
-        venice health
-        venice health --full
-        venice health --wallet --wallet-env MY_WALLET_KEY
+        venice-py health
+        venice-py health --full
+        venice-py health --wallet --wallet-env MY_WALLET_KEY
     """
     api_key = ensure_api_key()
     asyncio.run(_run_checks(api_key, full=full, wallet=wallet, wallet_env=wallet_env))
@@ -96,7 +96,7 @@ def health_command(
 
 async def _run_checks(api_key: str, *, full: bool, wallet: bool, wallet_env: str) -> None:
     """Run the health check sequence; print results; raise SystemExit on failure."""
-    OutputManager.info("venice health")
+    OutputManager.info("venice-py health")
     results: list[_CheckResult] = []
 
     # 1. API key presence — already validated by ensure_api_key, but record it.

--- a/src/venice_ai/cli/commands/image/edit.py
+++ b/src/venice_ai/cli/commands/image/edit.py
@@ -79,9 +79,9 @@ def edit_image(
 
     Examples:
 
-        venice image edit photo.jpg --prompt "Add a rainbow to the sky"
+        venice-py image edit photo.jpg --prompt "Add a rainbow to the sky"
 
-        venice image edit portrait.png --prompt "Change hair color to red"
+        venice-py image edit portrait.png --prompt "Change hair color to red"
     """
     asyncio.run(
         _edit_async(
@@ -242,9 +242,9 @@ def remove_bg(
 
     Examples:
 
-        venice image remove-bg photo.jpg
+        venice-py image remove-bg photo.jpg
 
-        venice image remove-bg product.png --save-dir ./cutouts --open
+        venice-py image remove-bg product.png --save-dir ./cutouts --open
     """
     asyncio.run(_remove_bg_async(ctx, input_file, output, save_dir, img_format, open_image))
 

--- a/src/venice_ai/cli/commands/image/generate.py
+++ b/src/venice_ai/cli/commands/image/generate.py
@@ -120,16 +120,16 @@ def generate_image(
     Examples:
 
         # Basic usage
-        venice image generate "sunset over mountains"
+        venice-py image generate "sunset over mountains"
 
         # With advanced parameters
-        venice image generate "cyberpunk city" --steps 30 --cfg-scale 8.5 --style-preset Cinematic
+        venice-py image generate "cyberpunk city" --steps 30 --cfg-scale 8.5 --style-preset Cinematic
 
         # Using a preset
-        venice image generate "portrait photo" --preset photorealistic
+        venice-py image generate "portrait photo" --preset photorealistic
 
         # Interactive mode
-        venice image generate --interactive
+        venice-py image generate --interactive
     """
     if interactive:
         # Lazy import to avoid circular dependency (wizard imports _generate_image_async)

--- a/src/venice_ai/cli/commands/image/multi_edit.py
+++ b/src/venice_ai/cli/commands/image/multi_edit.py
@@ -93,9 +93,9 @@ def multi_edit_image(
 
     Examples:
 
-        venice image multi-edit --prompt "combine these" --image base.png
+        venice-py image multi-edit --prompt "combine these" --image base.png
 
-        venice image multi-edit -p "blend" -i base.png --image-2 overlay.png
+        venice-py image multi-edit -p "blend" -i base.png --image-2 overlay.png
     """
     asyncio.run(
         _multi_edit_async(

--- a/src/venice_ai/cli/commands/image/presets_cmd.py
+++ b/src/venice_ai/cli/commands/image/presets_cmd.py
@@ -89,7 +89,7 @@ async def _manage_presets_async(ctx: click.Context):
                 )
 
             console.print(table)
-            print_info("\nUse with: venice image generate 'prompt' --preset <name>")
+            print_info("\nUse with: venice-py image generate 'prompt' --preset <name>")
 
         elif action == "Save current config as preset":
             preset_name = await asyncio.to_thread(

--- a/src/venice_ai/cli/commands/image/styles.py
+++ b/src/venice_ai/cli/commands/image/styles.py
@@ -49,7 +49,7 @@ async def _list_styles_async(ctx: click.Context):
 
             console.print(table)
             print_success(f"\nFound {len(response.data)} available styles")
-            print_info("Use with: venice image generate 'prompt' --style-preset 'Style Name'")
+            print_info("Use with: venice-py image generate 'prompt' --style-preset 'Style Name'")
 
         except Exception as e:
             print_error(f"Failed to fetch styles: {e}")

--- a/src/venice_ai/cli/commands/image/upscale.py
+++ b/src/venice_ai/cli/commands/image/upscale.py
@@ -59,9 +59,9 @@ def upscale_image(
 
     Examples:
 
-        venice image upscale photo.jpg --scale 2
+        venice-py image upscale photo.jpg --scale 2
 
-        venice image upscale photo.png --scale 4 --enhance --save-dir ./upscaled
+        venice-py image upscale photo.png --scale 4 --enhance --save-dir ./upscaled
     """
     asyncio.run(
         _upscale_async(

--- a/src/venice_ai/cli/commands/lint.py
+++ b/src/venice_ai/cli/commands/lint.py
@@ -1,4 +1,4 @@
-"""``venice lint <path>`` — flag v1 / OpenAI-style / non-idiomatic Venice patterns.
+"""``venice-py lint <path>`` — flag v1 / OpenAI-style / non-idiomatic Venice patterns.
 
 Wraps :mod:`venice_ai.cli.utils.lint_rules` as a Click subcommand. Reports
 findings in flake8-compatible ``path:line:col: CODE message`` format and
@@ -48,11 +48,11 @@ def lint_command(
 
     Examples::
 
-        venice lint src/
+        venice-py lint src/
 
-        venice lint --strict path/to/file.py
+        venice-py lint --strict path/to/file.py
 
-        venice lint --code V100 --code V200 src/
+        venice-py lint --code V100 --code V200 src/
     """
     findings: list[Finding] = lint_path(path, codes=codes if codes else None)
 

--- a/src/venice_ai/cli/commands/models/capabilities.py
+++ b/src/venice_ai/cli/commands/models/capabilities.py
@@ -1,4 +1,4 @@
-"""``venice models capabilities <id>`` — typed capability view.
+"""``venice-py models capabilities <id>`` — typed capability view.
 
 Wraps :meth:`venice_ai.resources.models.Models.get_capabilities`. The
 SDK returns one of :class:`ChatCapabilities` / :class:`ImageCapabilities` /
@@ -28,8 +28,8 @@ def capabilities(ctx: click.Context, model_id: str, output_json: bool) -> None:
 
     Examples:
 
-      venice models capabilities llama-3.3-70b
-      venice models capabilities flux-dev --json
+      venice-py models capabilities llama-3.3-70b
+      venice-py models capabilities flux-dev --json
     """
     asyncio.run(_capabilities_async(ctx, model_id=model_id, output_json=output_json))
 

--- a/src/venice_ai/cli/commands/models/get.py
+++ b/src/venice_ai/cli/commands/models/get.py
@@ -1,4 +1,4 @@
-"""``venice models get <id>`` — fetch a single ModelResponse.
+"""``venice-py models get <id>`` — fetch a single ModelResponse.
 
 Wraps :meth:`venice_ai.resources.models.Models.get`.
 """
@@ -22,8 +22,8 @@ def get(ctx: click.Context, model_id: str, output_json: bool) -> None:
 
     Examples:
 
-      venice models get llama-3.3-70b
-      venice models get qwen3-235b --json
+      venice-py models get llama-3.3-70b
+      venice-py models get qwen3-235b --json
     """
     asyncio.run(_get_async(ctx, model_id=model_id, output_json=output_json))
 

--- a/src/venice_ai/cli/commands/models/group.py
+++ b/src/venice_ai/cli/commands/models/group.py
@@ -1,17 +1,17 @@
-"""``venice models`` Click group.
+"""``venice-py models`` Click group.
 
-Wraps the historical ``venice models`` listing command (kept as the
+Wraps the historical ``venice-py models`` listing command (kept as the
 default callback when no subcommand is supplied, so existing flag-based
-invocations like ``venice models --type text`` keep working) and hangs
+invocations like ``venice-py models --type text`` keep working) and hangs
 new model-discovery subcommands off the same group.
 
 Subcommands:
-    - ``venice models resolve --type <type> ...`` — wraps
+    - ``venice-py models resolve --type <type> ...`` — wraps
       :meth:`venice_ai.resources.models.Models.resolve` and the eleven
       ``resolve_*`` shortcuts.
-    - ``venice models get <id>`` — wraps
+    - ``venice-py models get <id>`` — wraps
       :meth:`venice_ai.resources.models.Models.get`.
-    - ``venice models capabilities <id>`` — wraps
+    - ``venice-py models capabilities <id>`` — wraps
       :meth:`venice_ai.resources.models.Models.get_capabilities`.
 """
 
@@ -91,27 +91,27 @@ def models(ctx: click.Context, **kwargs) -> None:
     """List, filter, resolve, and inspect available AI models.
 
     With no subcommand, lists models with the supplied filter flags.
-    Use ``venice models <subcommand> --help`` for resolve/get/capabilities.
+    Use ``venice-py models <subcommand> --help`` for resolve/get/capabilities.
 
     Examples:
 
       # List all models (default)
-      venice models
+      venice-py models
 
       # Show only text models
-      venice models --type text
+      venice-py models --type text
 
       # Filter by capabilities
-      venice models --vision --function-calling
+      venice-py models --vision --function-calling
 
       # Resolve the cheapest chat model with function calling
-      venice models resolve --type chat --function-calling
+      venice-py models resolve --type chat --function-calling
 
       # Inspect a single model
-      venice models get llama-3.3-70b
+      venice-py models get llama-3.3-70b
 
       # Get a typed capability view
-      venice models capabilities llama-3.3-70b
+      venice-py models capabilities llama-3.3-70b
     """
     if ctx.invoked_subcommand is not None:
         # Subcommand will run instead — drop top-level filter flags.

--- a/src/venice_ai/cli/commands/models/resolve.py
+++ b/src/venice_ai/cli/commands/models/resolve.py
@@ -1,4 +1,4 @@
-"""``venice models resolve`` — auto-pick a model by type and capabilities.
+"""``venice-py models resolve`` — auto-pick a model by type and capabilities.
 
 Wraps :meth:`venice_ai.resources.models.Models.resolve` and the eleven
 ``resolve_*`` shortcuts (chat / embedding / image / video / tts / asr /
@@ -113,13 +113,13 @@ def resolve(
 
     Examples:
 
-      venice models resolve --type chat
-      venice models resolve --type chat --function-calling --vision
-      venice models resolve --type embedding
-      venice models resolve --type video --audio --min-resolution 720p
-      venice models resolve --type cheapest-video --duration 5s
-      venice models resolve --type video-upscale
-      venice models resolve --type chat --json
+      venice-py models resolve --type chat
+      venice-py models resolve --type chat --function-calling --vision
+      venice-py models resolve --type embedding
+      venice-py models resolve --type video --audio --min-resolution 720p
+      venice-py models resolve --type cheapest-video --duration 5s
+      venice-py models resolve --type video-upscale
+      venice-py models resolve --type chat --json
     """
     asyncio.run(
         _resolve_async(

--- a/src/venice_ai/cli/commands/skills.py
+++ b/src/venice_ai/cli/commands/skills.py
@@ -1,4 +1,4 @@
-"""``venice skills`` — install the SDK's bundled Claude Code skills.
+"""``venice-py skills`` — install the SDK's bundled Claude Code skills.
 
 The four skills ship as package data under ``venice_ai/skills/<name>/`` and are
 copied into a project-local (default) or global ``.claude/skills/`` directory so
@@ -122,9 +122,9 @@ def install_skills(names: tuple[str, ...], global_: bool, force: bool, dry_run: 
 
     Examples::
 
-        venice skills install
-        venice skills install venice-ai venice-ai-x402 --global
-        venice skills install --force
+        venice-py skills install
+        venice-py skills install venice-ai venice-ai-x402 --global
+        venice-py skills install --force
     """
     bundled = available_skills()
     targets = list(names) if names else bundled

--- a/src/venice_ai/cli/commands/video.py
+++ b/src/venice_ai/cli/commands/video.py
@@ -147,7 +147,7 @@ def _determine_output_path(output: str | None, save_dir: str, ext: str = "mp4") 
 
 
 # ---------------------------------------------------------------------------
-# venice video generate
+# venice-py video generate
 # ---------------------------------------------------------------------------
 
 
@@ -255,13 +255,13 @@ def generate(
 
     Examples:
 
-      venice video generate "A sunset over the ocean with gentle waves"
+      venice-py video generate "A sunset over the ocean with gentle waves"
 
-      venice video generate "A cat playing piano" --duration 10s --model <video-model>
+      venice-py video generate "A cat playing piano" --duration 10s --model <video-model>
 
-      venice video generate "Cinematic drone shot" --aspect-ratio 16:9 --resolution 1080p
+      venice-py video generate "Cinematic drone shot" --aspect-ratio 16:9 --resolution 1080p
 
-      venice video generate "Quick preview" --no-poll
+      venice-py video generate "Quick preview" --no-poll
     """
     asyncio.run(
         _generate_async(
@@ -351,7 +351,7 @@ async def _generate_async(
         OutputManager.success(f"Job queued! Job ID: {queue_id}")
 
         if no_poll:
-            OutputManager.echo(f"Use 'venice video status {queue_id}' to check progress.")
+            OutputManager.echo(f"Use 'venice-py video status {queue_id}' to check progress.")
             return
 
         output_path = _determine_output_path(output, save_dir)
@@ -371,7 +371,7 @@ async def _generate_async(
 
 
 # ---------------------------------------------------------------------------
-# venice video from-image
+# venice-py video from-image
 # ---------------------------------------------------------------------------
 
 
@@ -478,13 +478,13 @@ def from_image(
 
     Examples:
 
-      venice video from-image photo.jpg
+      venice-py video from-image photo.jpg
 
-      venice video from-image photo.png --prompt "Gentle breeze through the trees"
+      venice-py video from-image photo.png --prompt "Gentle breeze through the trees"
 
-      venice video from-image portrait.jpg --model <i2v-model> --duration 10s
+      venice-py video from-image portrait.jpg --model <i2v-model> --duration 10s
 
-      venice video from-image landscape.jpg --no-poll
+      venice-py video from-image landscape.jpg --no-poll
     """
     asyncio.run(
         _from_image_async(
@@ -577,7 +577,7 @@ async def _from_image_async(
         OutputManager.success(f"Job queued! Job ID: {queue_id}")
 
         if no_poll:
-            OutputManager.echo(f"Use 'venice video status {queue_id}' to check progress.")
+            OutputManager.echo(f"Use 'venice-py video status {queue_id}' to check progress.")
             return
 
         output_path = _determine_output_path(output, save_dir)
@@ -597,7 +597,7 @@ async def _from_image_async(
 
 
 # ---------------------------------------------------------------------------
-# venice video status
+# venice-py video status
 # ---------------------------------------------------------------------------
 
 
@@ -617,9 +617,9 @@ def status(ctx, job_id, model):
 
     Examples:
 
-      venice video status abc123
+      venice-py video status abc123
 
-      venice video status abc123 --model <i2v-model>
+      venice-py video status abc123 --model <i2v-model>
     """
     asyncio.run(_status_async(ctx, job_id=job_id, model=model))
 

--- a/src/venice_ai/cli/config.py
+++ b/src/venice_ai/cli/config.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 
 # ``yaml`` is gated behind the ``[cli]`` extra. Lazy-import it inside the
 # read/write helpers so subcommands that don't touch the config file (e.g.
-# ``venice lint``) work on a bare ``pip install venice-ai`` install.
+# ``venice-py lint``) work on a bare ``pip install venice-ai`` install.
 
 # Load environment variables
 load_dotenv()
@@ -22,7 +22,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "defaults": {
         # Model IDs are intentionally NOT defaulted here. When unset, the CLI
         # resolves a model from the live /models API at runtime (see
-        # cli/_model_defaults.py). A user's choice in `venice configure` is
+        # cli/_model_defaults.py). A user's choice in `venice-py configure` is
         # written back here per-key.
         "max_completion_tokens": 2048,
         "temperature": 0.7,
@@ -167,7 +167,7 @@ def ensure_api_key(config_path: Path | None = None) -> str:
     if not api_key:
         raise click.ClickException(
             "No API key found. Set it using:\n"
-            "  1. Run: venice configure\n"
+            "  1. Run: venice-py configure\n"
             "  2. Or set environment variable: export VENICE_API_KEY=your-key"
         )
     return api_key

--- a/src/venice_ai/cli/utils/lint_rules.py
+++ b/src/venice_ai/cli/utils/lint_rules.py
@@ -1,7 +1,7 @@
 """AST-based linter for v1 / OpenAI-style / non-idiomatic Venice patterns.
 
 Walks Python source files and reports patterns that won't work (or work
-sub-optimally) on Venice SDK v2. Used by the ``venice lint`` CLI subcommand
+sub-optimally) on Venice SDK v2. Used by the ``venice-py lint`` CLI subcommand
 and importable as a library for tooling integrations (e.g., a future
 ``ruff`` plugin).
 

--- a/src/venice_ai/skills/venice-ai-production/SKILL.md
+++ b/src/venice_ai/skills/venice-ai-production/SKILL.md
@@ -125,7 +125,7 @@ solves it: pass an empty tracker at construction time, then hydrate
 pricing once the client is open. Pass `populate_pricing=False` if you've
 already supplied a pricing map yourself or want to skip the round-trip.
 
-**Field names that bite** (`venice lint` flags V502/V503):
+**Field names that bite** (`venice-py lint` flags V502/V503):
 - `tracker.total_cost_usd` (NOT `tracker.total`)
 - `tracker.total_tokens` (NOT `tracker.calls`)
 - `len(tracker.requests)` for call count

--- a/src/venice_ai/skills/venice-ai-x402/SKILL.md
+++ b/src/venice_ai/skills/venice-ai-x402/SKILL.md
@@ -174,7 +174,7 @@ These integrations are evolving. Don't trust a code snippet from training data �
 
 1. **Passing `wallet_address=` to `X402Auth`** — no such kwarg; address is derived. Use `auth.wallet_address` (property) to read it.
 2. **Calling a fictional `auth.payment_header(amount_usd=...)`** — doesn't exist. `X402Auth` signs SIWE only. For payment headers use `auth.build_payment_header(requirement)` or, for the common case, `client.x402.top_up_with(...)`.
-3. **Treating `PaymentRequiredError` as transient** — it's terminal. The structured requirements live on `e.body` (NOT `e.payment_instructions` — `venice lint` flags this as V601). Sign a payment, then retry the original op.
+3. **Treating `PaymentRequiredError` as transient** — it's terminal. The structured requirements live on `e.body` (NOT `e.payment_instructions` — `venice-py lint` flags this as V601). Sign a payment, then retry the original op.
 4. **Signing SIWE on every call** instead of reusing one `X402Auth` instance within its TTL window — `VeniceClient(auth=auth)` caches the token internally, so this only matters for raw-HTTP code.
 5. **Forgetting the `[x402]` extra** — `from venice_ai.auth.x402 import X402Auth` ImportError is a setup smell. (Solana settlement needs the separate `[x402-solana]` extra.)
 6. **Committing the private key** — the wallet IS the agent's credentials; see `references/wallet-security.md`.

--- a/src/venice_ai/skills/venice-ai/SKILL.md
+++ b/src/venice_ai/skills/venice-ai/SKILL.md
@@ -324,7 +324,7 @@ See `references/migration-v1-to-v2.md` for the full v2 breaking-change list with
 15. **Music & video model duration values are model-specific enums** — `client.music.run(model="ace-step-15", duration_seconds=30)` is a 400 because that model only accepts `[60, 90, 120, 150, 180, 210]`. As of 2.0 the SDK pre-validates against `spec.duration_options` (or `min_duration` / `max_duration`) and raises `ValueError` before the HTTP call when the spec is reachable; if the catalog can't be fetched, the server is the backstop. Either way: read `client.models.get(model_id).model_spec` for the per-model tier list when picking durations.
 16. **Tool function args using PEP 604 unions like `int | None`** — `tool_from_function` accepts both `Optional[T]` and `T | None` identically; either works for an optional tool parameter.
 
-To catch these patterns automatically in user code, run **`venice lint <path>`** (built into the CLI on SDK ≥ 2.0.0). Reports findings in flake8-compatible `path:line:col: CODE message` format; supports `--code` filtering and `--strict`. See the venice-ai CLI docs for the full rule-code table.
+To catch these patterns automatically in user code, run **`venice-py lint <path>`** (built into the CLI on SDK ≥ 2.0.0). Reports findings in flake8-compatible `path:line:col: CODE message` format; supports `--code` filtering and `--strict`. See the venice-ai CLI docs for the full rule-code table.
 
 ## References
 
@@ -341,7 +341,7 @@ To catch these patterns automatically in user code, run **`venice lint <path>`**
 
 ## Scripts
 
-- `scripts/lint_v1_usage.py <path>` — AST-walks a directory and flags v1 / legacy / non-idiomatic patterns: `max_tokens=`, `client.image.generate(`, `client.audio.generate_music(`, hardcoded model strings on `model=` kwargs. Legacy: prefer `venice lint <path>` on SDK ≥ 2.0.0; same rules, discoverable via `venice --help`.
+- `scripts/lint_v1_usage.py <path>` — AST-walks a directory and flags v1 / legacy / non-idiomatic patterns: `max_tokens=`, `client.image.generate(`, `client.audio.generate_music(`, hardcoded model strings on `model=` kwargs. Legacy: prefer `venice-py lint <path>` on SDK ≥ 2.0.0; same rules, discoverable via `venice-py --help`.
 
 ## Examples to read
 

--- a/src/venice_ai/skills/venice-ai/references/migration-v1-to-v2.md
+++ b/src/venice_ai/skills/venice-ai/references/migration-v1-to-v2.md
@@ -70,7 +70,7 @@ The new async-job resources (`video`, `music`) use a consistent verb scheme — 
 
 ## Patterns the linter flags (not real v2 methods)
 
-`venice lint <path>` flags calls that won't run on v2 — including method names that look plausible but **do not exist in v2** (often from OpenAI habits or stale docs). These are *not* old v1 methods; they're mistakes to avoid:
+`venice-py lint <path>` flags calls that won't run on v2 — including method names that look plausible but **do not exist in v2** (often from OpenAI habits or stale docs). These are *not* old v1 methods; they're mistakes to avoid:
 
 - `client.audio.generate_music(...)` → use `client.music.run(...)` (V102)
 - `client.audio.generate_speech(...)` → use `client.audio.create_speech(...)` (V103)
@@ -81,7 +81,7 @@ The new async-job resources (`video`, `music`) use a consistent verb scheme — 
 plus the genuine v1 patterns it catches: `AsyncVeniceClient` (V100), `client.image.generate(...)` (V101), and `max_tokens=`.
 
 ```bash
-venice lint src/     # ships with SDK >= 2.0.0; discoverable via venice --help
+venice-py lint src/     # ships with SDK >= 2.0.0; discoverable via venice-py --help
 ```
 
 (The skill also ships a standalone copy at `scripts/lint_v1_usage.py` you can run directly.)

--- a/src/venice_ai/skills/venice-ai/scripts/lint_v1_usage.py
+++ b/src/venice_ai/skills/venice-ai/scripts/lint_v1_usage.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Flag v1 / OpenAI-style / non-idiomatic patterns in Venice v2 codebases.
 
-NOTE: On SDK >= 2.0.0, prefer ``venice lint <path>`` (the built-in CLI
+NOTE: On SDK >= 2.0.0, prefer ``venice-py lint <path>`` (the built-in CLI
 subcommand) — same rule codes, same flake8-style output, plus discoverable
-via ``venice --help``. This script exists for users on older SDK versions
+via ``venice-py --help``. This script exists for users on older SDK versions
 or as a standalone tool that doesn't require installing the SDK.
 
 Walks Python files under a target path and reports:

--- a/tests/cli/commands/models/test_capabilities.py
+++ b/tests/cli/commands/models/test_capabilities.py
@@ -1,4 +1,4 @@
-"""Tests for ``venice models capabilities`` (cli/commands/models/capabilities.py)."""
+"""Tests for ``venice-py models capabilities`` (cli/commands/models/capabilities.py)."""
 
 from __future__ import annotations
 

--- a/tests/cli/commands/models/test_get.py
+++ b/tests/cli/commands/models/test_get.py
@@ -1,4 +1,4 @@
-"""Tests for ``venice models get`` (cli/commands/models/get.py)."""
+"""Tests for ``venice-py models get`` (cli/commands/models/get.py)."""
 
 from __future__ import annotations
 

--- a/tests/cli/commands/models/test_resolve.py
+++ b/tests/cli/commands/models/test_resolve.py
@@ -1,4 +1,4 @@
-"""Tests for ``venice models resolve`` (cli/commands/models/resolve.py)."""
+"""Tests for ``venice-py models resolve`` (cli/commands/models/resolve.py)."""
 
 from __future__ import annotations
 

--- a/tests/cli/commands/test_account_keys.py
+++ b/tests/cli/commands/test_account_keys.py
@@ -1,4 +1,4 @@
-"""Tests for ``venice account keys get|update`` (cli/commands/account.py)."""
+"""Tests for ``venice-py account keys get|update`` (cli/commands/account.py)."""
 
 from __future__ import annotations
 
@@ -63,7 +63,7 @@ def _make_api_key(
 
 
 # ---------------------------------------------------------------------------
-# `venice account keys` group + `keys get` subcommand
+# `venice-py account keys` group + `keys get` subcommand
 # ---------------------------------------------------------------------------
 
 

--- a/tests/cli/commands/test_audio_voices.py
+++ b/tests/cli/commands/test_audio_voices.py
@@ -1,4 +1,4 @@
-"""Tests for ``venice audio voices`` (cli/commands/audio.py)."""
+"""Tests for ``venice-py audio voices`` (cli/commands/audio.py)."""
 
 from __future__ import annotations
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -312,7 +312,7 @@ class TestModuleConstants:
         """__version__ must match installed package metadata.
 
         Regression guard: the value was hardcoded to "2.0.0" while the
-        installed package was "2.0.0rc1", so ``venice --version`` lied.
+        installed package was "2.0.0rc1", so ``venice-py --version`` lied.
         """
         from importlib.metadata import version as _installed_version
 

--- a/tests/cli/test_health.py
+++ b/tests/cli/test_health.py
@@ -1,4 +1,4 @@
-"""Tests for the ``venice health`` CLI subcommand.
+"""Tests for the ``venice-py health`` CLI subcommand.
 
 Mocks every network-touching call (`models.list`, `billing.get_balance`,
 `embeddings.create`, `x402.balance`) so the tests run offline. Asserts on

--- a/tests/cli/test_help_grouping.py
+++ b/tests/cli/test_help_grouping.py
@@ -1,4 +1,4 @@
-"""Tests for the curated ``venice --help`` command-group layout."""
+"""Tests for the curated ``venice-py --help`` command-group layout."""
 
 from __future__ import annotations
 
@@ -50,5 +50,5 @@ def test_help_top_text_mentions_featured_commands() -> None:
     result = runner.invoke(cli, ["--help"])
     assert result.exit_code == 0
     out = result.output
-    assert "venice models resolve" in out
-    assert "venice lint" in out
+    assert "venice-py models resolve" in out
+    assert "venice-py lint" in out

--- a/tests/cli/test_image_command_comprehensive.py
+++ b/tests/cli/test_image_command_comprehensive.py
@@ -2972,14 +2972,14 @@ class TestEditAsync:
 
     def test_edit_command_has_no_mask_option(self):
         """``mask`` (inpainting) is dead code — the server rejects it.
-        The ``venice image edit`` command must not expose a ``--mask`` option."""
+        The ``venice-py image edit`` command must not expose a ``--mask`` option."""
         param_names = {p.name for p in edit_image.params}
         assert "mask" not in param_names
 
 
 class TestEditNewFlags:
     """--aspect-ratio, --resolution, --output-format, --safe-mode flags
-    on ``venice image edit``, mirroring ``image multi-edit``. Each maps to a real
+    on ``venice-py image edit``, mirroring ``image multi-edit``. Each maps to a real
     ``client.image.edit()`` kwarg."""
 
     @pytest.fixture

--- a/tests/cli/test_lint.py
+++ b/tests/cli/test_lint.py
@@ -1,4 +1,4 @@
-"""Tests for the ``venice lint`` CLI subcommand and its underlying rules.
+"""Tests for the ``venice-py lint`` CLI subcommand and its underlying rules.
 
 Covers:
 
@@ -6,7 +6,7 @@ Covers:
   fires on a known-bad fixture snippet and stays silent on a clean snippet.
 - :func:`venice_ai.cli.utils.lint_rules.lint_path` — file vs directory walk,
   ``--code`` filter behavior, skip-dir heuristics.
-- ``venice lint`` Click command — exit codes (clean=0, info-only=0,
+- ``venice-py lint`` Click command — exit codes (clean=0, info-only=0,
   errors=1, info-only-with-strict=1), output format, ``--code`` filter.
 """
 
@@ -236,7 +236,7 @@ def test_lint_file_reports_syntax_error_as_v000(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Click command — `venice lint <path>`
+# Click command — `venice-py lint <path>`
 # ---------------------------------------------------------------------------
 
 
@@ -331,12 +331,12 @@ def test_informational_codes_are_known_codes() -> None:
 
 
 # ---------------------------------------------------------------------------
-# venice lint must run without the [cli] extra
+# venice-py lint must run without the [cli] extra
 # ---------------------------------------------------------------------------
 
 
 def test_lint_runs_without_pyyaml(tmp_path: Path, monkeypatch) -> None:
-    """``venice lint`` is the most useful subcommand for codebases-using-venice;
+    """``venice-py lint`` is the most useful subcommand for codebases-using-venice;
     it must work on a bare ``pip install venice-ai`` install (no ``[cli]`` extra,
     no PyYAML).
 

--- a/tests/cli/test_model_defaults.py
+++ b/tests/cli/test_model_defaults.py
@@ -60,4 +60,4 @@ async def test_offline_raises_clickexception():
     with pytest.raises(click.ClickException) as exc:
         await resolve_default_model(client, {"defaults": {}}, "chat", explicit=None)
     assert "--model" in str(exc.value)
-    assert "venice configure" in str(exc.value)
+    assert "venice-py configure" in str(exc.value)

--- a/tests/cli/test_skills_command.py
+++ b/tests/cli/test_skills_command.py
@@ -1,4 +1,4 @@
-"""Tests for the ``venice skills`` CLI command group."""
+"""Tests for the ``venice-py skills`` CLI command group."""
 
 from __future__ import annotations
 

--- a/tools/cli_parity_check.py
+++ b/tools/cli_parity_check.py
@@ -62,13 +62,13 @@ KNOWN_CLI_MAP: dict[str, tuple[str, list[str], str]] = {
     ),
     "chat.completions.create": (
         "covered",
-        ["venice chat start"],
+        ["venice-py chat start"],
         "Both stream=True (default) and stream=False paths are reachable.",
     ),
     "chat.completions.estimate_cost": (
         "missing",
         [],
-        "No `venice chat estimate-cost` (or similar) command.",
+        "No `venice-py chat estimate-cost` (or similar) command.",
     ),
     "chat.completions.parse": (
         "missing",
@@ -82,33 +82,33 @@ KNOWN_CLI_MAP: dict[str, tuple[str, list[str], str]] = {
     ),
     "chat.completions.stream": (
         "partial",
-        ["venice chat start --stream"],
+        ["venice-py chat start --stream"],
         "CLI calls `create(stream=True)` directly, not the `.stream()` helper.",
     ),
     # ---- image ----
     "image.background_remove": (
         "covered",
-        ["venice image remove-bg"],
+        ["venice-py image remove-bg"],
         "",
     ),
     "image.create": (
         "covered",
-        ["venice image generate", "venice image batch"],
+        ["venice-py image generate", "venice-py image batch"],
         "Full parameter surface incl. style presets, LoRA, watermark, EXIF.",
     ),
     "image.edit": (
         "covered",
-        ["venice image edit"],
+        ["venice-py image edit"],
         "Exposes --aspect-ratio, --resolution, --output-format, --safe-mode/--no-safe-mode.",
     ),
     "image.list_styles": (
         "covered",
-        ["venice image list-styles"],
+        ["venice-py image list-styles"],
         "",
     ),
     "image.multi_edit": (
         "covered",
-        ["venice image multi-edit"],
+        ["venice-py image multi-edit"],
         "Layers up to 3 images (--image, --image-2, --image-3) with one prompt.",
     ),
     "image.simple_generate": (
@@ -118,15 +118,15 @@ KNOWN_CLI_MAP: dict[str, tuple[str, list[str], str]] = {
     ),
     "image.upscale": (
         "covered",
-        ["venice image upscale"],
+        ["venice-py image upscale"],
         "",
     ),
     # ---- video ----
     "video.cancel": (
         "partial",
-        ["venice video status (auto-cancels on Ctrl-C)"],
+        ["venice-py video status (auto-cancels on Ctrl-C)"],
         "Cancel is invoked implicitly by the polling loop, not as a standalone "
-        "`venice video cancel <job_id>`.",
+        "`venice-py video cancel <job_id>`.",
     ),
     "video.quote": (
         "missing",
@@ -135,18 +135,18 @@ KNOWN_CLI_MAP: dict[str, tuple[str, list[str], str]] = {
     ),
     "video.retrieve": (
         "covered",
-        ["venice video status"],
+        ["venice-py video status"],
         "Used to poll job status by queue_id.",
     ),
     "video.run": (
         "partial",
-        ["venice video generate", "venice video from-image"],
+        ["venice-py video generate", "venice-py video from-image"],
         "CLI uses `submit` + `retrieve` polling rather than the high-level "
         "`run` helper. Equivalent end result.",
     ),
     "video.submit": (
         "covered",
-        ["venice video generate --no-poll", "venice video from-image --no-poll"],
+        ["venice-py video generate --no-poll", "venice-py video from-image --no-poll"],
         "",
     ),
     "video.transcribe": (
@@ -157,17 +157,17 @@ KNOWN_CLI_MAP: dict[str, tuple[str, list[str], str]] = {
     # ---- audio ----
     "audio.create_speech": (
         "covered",
-        ["venice audio speak"],
+        ["venice-py audio speak"],
         "",
     ),
     "audio.get_voices": (
         "covered",
-        ["venice audio voices"],
+        ["venice-py audio voices"],
         "Filters by --model / --gender / --region; --json for scripting.",
     ),
     "audio.transcribe": (
         "covered",
-        ["venice audio transcribe"],
+        ["venice-py audio transcribe"],
         "",
     ),
     # ---- music ----
@@ -199,23 +199,23 @@ KNOWN_CLI_MAP: dict[str, tuple[str, list[str], str]] = {
     # ---- embeddings ----
     "embeddings.create": (
         "covered",
-        ["venice embeddings"],
+        ["venice-py embeddings"],
         "",
     ),
     # ---- models ----
     "models.get": (
         "covered",
-        ["venice models get <id>"],
+        ["venice-py models get <id>"],
         "Single-model lookup via the cached list; --json for raw payload.",
     ),
     "models.get_capabilities": (
         "covered",
-        ["venice models capabilities <id>"],
+        ["venice-py models capabilities <id>"],
         "Renders the typed Capabilities discriminated union.",
     ),
     "models.list": (
         "covered",
-        ["venice models", "venice configure", "venice chat start --select-model"],
+        ["venice-py models", "venice-py configure", "venice-py chat start --select-model"],
         "Used by multiple commands; primary discovery path.",
     ),
     "models.list_compatibility": (
@@ -225,69 +225,69 @@ KNOWN_CLI_MAP: dict[str, tuple[str, list[str], str]] = {
     ),
     "models.list_traits": (
         "partial",
-        ["venice models --trait <t>"],
+        ["venice-py models --trait <t>"],
         "CLI filters traits client-side from `list` results; never calls "
         "`list_traits` to get the canonical trait set.",
     ),
     "models.resolve": (
         "covered",
-        ["venice models resolve --type <type>"],
+        ["venice-py models resolve --type <type>"],
         "Single command exposes resolve() + every resolve_* shortcut via --type.",
     ),
     "models.resolve_asr": (
         "covered",
-        ["venice models resolve --type asr"],
+        ["venice-py models resolve --type asr"],
         "Routed through resolve() with type='asr'.",
     ),
     "models.resolve_chat": (
         "covered",
-        ["venice models resolve --type chat"],
+        ["venice-py models resolve --type chat"],
         "Carries chat capability flags (--function-calling, --vision, etc).",
     ),
     "models.resolve_cheapest_video": (
         "covered",
-        ["venice models resolve --type cheapest-video"],
+        ["venice-py models resolve --type cheapest-video"],
         "Renders the CheapestVideoResult with all-quotes table.",
     ),
     "models.resolve_embedding": (
         "covered",
-        ["venice models resolve --type embedding"],
+        ["venice-py models resolve --type embedding"],
         "",
     ),
     "models.resolve_image": (
         "covered",
-        ["venice models resolve --type image"],
+        ["venice-py models resolve --type image"],
         "",
     ),
     "models.resolve_inpaint": (
         "covered",
-        ["venice models resolve --type inpaint"],
+        ["venice-py models resolve --type inpaint"],
         "",
     ),
     "models.resolve_music": (
         "covered",
-        ["venice models resolve --type music"],
+        ["venice-py models resolve --type music"],
         "",
     ),
     "models.resolve_tts": (
         "covered",
-        ["venice models resolve --type tts"],
+        ["venice-py models resolve --type tts"],
         "",
     ),
     "models.resolve_video": (
         "covered",
-        ["venice models resolve --type video"],
+        ["venice-py models resolve --type video"],
         "Carries video filters (--video-type, --audio, --min-resolution, --min-duration).",
     ),
     "models.resolve_video_upscale": (
         "covered",
-        ["venice models resolve --type video-upscale"],
+        ["venice-py models resolve --type video-upscale"],
         "",
     ),
     # ---- api_keys ----
     "api_keys.create": (
         "covered",
-        ["venice api-keys create"],
+        ["venice-py api-keys create"],
         "",
     ),
     "api_keys.create_web3_key": (
@@ -297,7 +297,7 @@ KNOWN_CLI_MAP: dict[str, tuple[str, list[str], str]] = {
     ),
     "api_keys.delete": (
         "covered",
-        ["venice api-keys delete"],
+        ["venice-py api-keys delete"],
         "",
     ),
     "api_keys.get_rate_limit_logs": (
@@ -317,33 +317,33 @@ KNOWN_CLI_MAP: dict[str, tuple[str, list[str], str]] = {
     ),
     "api_keys.iter_all": (
         "partial",
-        ["venice api-keys list"],
+        ["venice-py api-keys list"],
         "CLI calls `list()` (single page). Auto-paginating helper not used.",
     ),
     "api_keys.list": (
         "covered",
-        ["venice api-keys list"],
+        ["venice-py api-keys list"],
         "",
     ),
     "api_keys.retrieve": (
         "covered",
-        ["venice account keys get <id>"],
+        ["venice-py account keys get <id>"],
         "Renders the bare ApiKey via Rich panel; --json for scripting.",
     ),
     "api_keys.update": (
         "covered",
-        ["venice account keys update <id> [--description ... | --expiry ... | --limit-* ...]"],
+        ["venice-py account keys update <id> [--description ... | --expiry ... | --limit-* ...]"],
         "Updates description / expiry / consumption limits.",
     ),
     # ---- characters ----
     "characters.get": (
         "covered",
-        ["venice characters info"],
+        ["venice-py characters info"],
         "",
     ),
     "characters.iter_all": (
         "partial",
-        ["venice characters list"],
+        ["venice-py characters list"],
         "CLI uses `list()` only; no pagination over full catalogue.",
     ),
     "characters.iter_reviews": (
@@ -353,7 +353,7 @@ KNOWN_CLI_MAP: dict[str, tuple[str, list[str], str]] = {
     ),
     "characters.list": (
         "covered",
-        ["venice characters list"],
+        ["venice-py characters list"],
         "Exposes --search, --sort-by/--sort-order, --tags, --categories, and status filters.",
     ),
     "characters.reviews": (
@@ -364,12 +364,12 @@ KNOWN_CLI_MAP: dict[str, tuple[str, list[str], str]] = {
     # ---- billing ----
     "billing.get_balance": (
         "covered",
-        ["venice account balance"],
+        ["venice-py account balance"],
         "",
     ),
     "billing.get_usage_history": (
         "covered",
-        ["venice account usage"],
+        ["venice-py account usage"],
         "",
     ),
     "billing.get_usage_analytics": (
@@ -379,7 +379,7 @@ KNOWN_CLI_MAP: dict[str, tuple[str, list[str], str]] = {
     ),
     "billing.iter_usage_history": (
         "partial",
-        ["venice account usage"],
+        ["venice-py account usage"],
         "CLI shows the first usage-history page plus a 'more available' hint; no auto-pagination.",
     ),
     # ---- augment ----

--- a/tools/skills/README.md
+++ b/tools/skills/README.md
@@ -1,11 +1,11 @@
 # Venice Claude Code skills
 
-Four [Claude Code skills](https://docs.claude.com/en/docs/claude-code/skills) that empower AI builders to write idiomatic Venice AI v2 code on the first try. They auto-load when their trigger contexts match — `venice chat`, `venice image`, `venice rate limit`, `venice x402`, etc.
+Four [Claude Code skills](https://docs.claude.com/en/docs/claude-code/skills) that empower AI builders to write idiomatic Venice AI v2 code on the first try. They auto-load when their trigger contexts match — `venice-py chat`, `venice-py image`, `venice rate limit`, `venice x402`, etc.
 
 | Skill | Purpose | Triggers on |
 |---|---|---|
-| **`venice-ai`** | Setup, chat, streaming, tool calling / agent loops, structured output, model resolution, embeddings, characters, augment, response metadata, v1→v2 migration | `venice_ai` import, `VeniceClient`, "venice chat / stream / tool / agent" |
-| **`venice-ai-multimodal`** | Image, audio (TTS + STT), video, music generation; save patterns; async-job lifecycle | "venice image / TTS / STT / video / music" |
+| **`venice-ai`** | Setup, chat, streaming, tool calling / agent loops, structured output, model resolution, embeddings, characters, augment, response metadata, v1→v2 migration | `venice_ai` import, `VeniceClient`, "venice-py chat / stream / tool / agent" |
+| **`venice-ai-multimodal`** | Image, audio (TTS + STT), video, music generation; save patterns; async-job lifecycle | "venice-py image / TTS / STT / video / music" |
 | **`venice-ai-production`** | Retries with `RateLimitError.retry_after_seconds`, bounded concurrency via `client.gather()`, header-driven cost tracking, error taxonomy, observability, prompt caching | "production venice", "rate limit", "track cost", "retry / backoff venice" |
 | **`venice-ai-x402`** | `client.x402.*` (balance, transactions, top_up, top_up_with), SIWE auth via `X402Auth`, agent-framework wiring (Coinbase Agentkit, Eliza, x402-axios) | "x402 venice", "SIWE", "venice without API key", "venice from autonomous agent" |
 
@@ -40,7 +40,7 @@ src/venice_ai/skills/<skill>/
 └── evals/evals.json   # benchmark prompts
 ```
 
-`SKILL.md` is the index/router — kept under the 500-line skill-creator guidance. References hold deep material. Scripts hold reusable utilities (e.g., `topup_eip3009.py` for x402 wallet top-up; `lint_v1_usage.py`, the standalone-script equivalent of `venice lint`).
+`SKILL.md` is the index/router — kept under the 500-line skill-creator guidance. References hold deep material. Scripts hold reusable utilities (e.g., `topup_eip3009.py` for x402 wallet top-up; `lint_v1_usage.py`, the standalone-script equivalent of `venice-py lint`).
 
 The skill directories live inside the `venice_ai` Python package (`src/venice_ai/skills/`) and are shipped in the wheel. They are accessible at runtime via `importlib.resources.files("venice_ai") / "skills" / "<name>" / "SKILL.md"`.
 
@@ -53,7 +53,7 @@ make skills-check          # size guard + example-path resolution + code-block l
 Four checks:
 1. **`check_skill_size.py`** — every `SKILL.md` is ≤500 lines (skill-creator guidance).
 2. **`check_skill_examples.py`** — every `examples/foo/bar.py` referenced in a SKILL.md or reference actually exists in `examples/`. Catches drift when example files get renamed.
-3. **`lint_skill_code.py`** — extracts every \`\`\`python code block from skill markdown and pipes it through `venice lint`. Catches non-idiomatic patterns IN the skills (e.g., a skill teaching the wrong stream-iteration mode).
+3. **`lint_skill_code.py`** — extracts every \`\`\`python code block from skill markdown and pipes it through `venice-py lint`. Catches non-idiomatic patterns IN the skills (e.g., a skill teaching the wrong stream-iteration mode).
 4. **`check_skill_symbols.py`** — verifies that SDK symbols (imports, constructor kwargs, attributes) referenced in skill code blocks actually exist in the installed package.
 
 CI runs all four on every PR touching `src/venice_ai/skills/` or `tools/skills/`, every push to `main`, and weekly to catch slow drift.

--- a/tools/skills/lint_skill_code.py
+++ b/tools/skills/lint_skill_code.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run ``venice lint`` against every Python code block in SKILL.md / references/*.md.
+"""Run ``venice-py lint`` against every Python code block in SKILL.md / references/*.md.
 
 Extracts ```python fenced code blocks from each markdown file under
 ``src/venice_ai/skills/<skill>/`` and pipes the body through the lint visitor. CI

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -50,13 +50,13 @@ Installing them uses the `venice` CLI, which ships as an optional extra:
 ```bash
 pip install 'venice-ai[cli]>=2'
 
-venice skills install            # → ./.claude/skills/
-venice skills install --global   # → ~/.claude/skills/
-venice skills list               # show bundled skills + install state
+venice-py skills install            # → ./.claude/skills/
+venice-py skills install --global   # → ~/.claude/skills/
+venice-py skills list               # show bundled skills + install state
 ```
 
 Open Claude Code in the project and the skills auto-load when their trigger
-contexts match (e.g. "venice chat", "venice image", "venice x402").
+contexts match (e.g. "venice-py chat", "venice-py image", "venice x402").
 
 ## Next steps
 

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -2,6 +2,21 @@
 
 Command-line interface for Venice AI. Chat with AI models, generate images, create audio and video, manage embeddings, and more — all from your terminal.
 
+The command is **`venice-py`**. It ships with this unofficial, community-maintained
+Python SDK and is a different program from Venice's official CLI, which is written in
+Node and invoked as `venice` — see [veniceai/venice-cli](https://github.com/veniceai/venice-cli)
+for that one. The two can be installed side by side.
+
+:::note Renamed in v2.1.0
+
+This command was `venice` in v2.0.x, which collided with the official CLI's binary of the
+same name. Update any scripts and aliases, and regenerate shell completions. Upgrading
+does not delete the old entry point — if `venice --version` still prints a Venice AI CLI
+banner, remove the leftover script with `rm "$(command -v venice)"` while the environment
+is active.
+
+:::
+
 ## Installation
 
 ### Prerequisites
@@ -30,7 +45,7 @@ poetry add 'venice-ai[cli]>=2'
 git clone https://github.com/sethbang/venice-ai.git
 cd venice-ai
 poetry install --all-extras
-poetry run venice --version
+poetry run venice-py --version
 ```
 
 ## Quick Start
@@ -40,16 +55,16 @@ poetry run venice --version
 export VENICE_API_KEY="your-api-key"
 
 # Or run the interactive setup wizard
-venice configure
+venice-py configure
 
 # Chat with an AI model
-venice chat start "What is quantum computing?"
+venice-py chat start "What is quantum computing?"
 
 # Generate an image
-venice image generate "A sunset over mountains"
+venice-py image generate "A sunset over mountains"
 
 # List available models
-venice models
+venice-py models
 ```
 
 ---
@@ -66,7 +81,7 @@ These options apply to the top-level `venice` command and affect all subcommands
 | `--help` | Show help text for any command |
 
 ```bash
-venice --version
+venice-py --version
 venice --plain chat start "Hello"
 venice --config /path/to/config.yaml models
 ```
@@ -74,7 +89,7 @@ venice --config /path/to/config.yaml models
 `--config <path>` is resolved for **all** subcommands: the chosen file's
 `api.key` and `api.base_url` are applied to every client the CLI constructs.
 The `VENICE_API_KEY` environment variable still takes precedence over
-`api.key` in the file. `venice configure` reads from and writes back to the
+`api.key` in the file. `venice-py configure` reads from and writes back to the
 same `--config` path, so `venice --config ./team.yaml configure` edits that
 file rather than the default `~/.venice/config.yaml`.
 
@@ -87,7 +102,7 @@ file rather than the default `~/.venice/config.yaml`.
 Run the configuration wizard to set your API key, default models, generation parameters, and output settings:
 
 ```bash
-venice configure
+venice-py configure
 ```
 
 The wizard walks through:
@@ -136,13 +151,13 @@ Generate shell completion scripts for tab-completion of commands and options.
 
 ```bash
 # Bash
-venice completion bash >> ~/.bashrc
+venice-py completion bash >> ~/.bashrc
 
 # Zsh
-venice completion zsh >> ~/.zshrc
+venice-py completion zsh >> ~/.zshrc
 
 # Fish
-venice completion fish > ~/.config/fish/completions/venice.fish
+venice-py completion fish > ~/.config/fish/completions/venice.fish
 ```
 
 ---
@@ -151,12 +166,12 @@ venice completion fish > ~/.config/fish/completions/venice.fish
 
 Chat with AI models via streaming or one-shot messages. Supports interactive sessions, conversation history, piped input, Venice-specific parameters, and JSON output.
 
-### `venice chat start`
+### `venice-py chat start`
 
 Start an interactive chat session or send a single message.
 
 ```bash
-venice chat start [MESSAGE] [OPTIONS]
+venice-py chat start [MESSAGE] [OPTIONS]
 ```
 
 #### Arguments
@@ -199,50 +214,50 @@ venice chat start [MESSAGE] [OPTIONS]
 
 ```bash
 # Interactive session
-venice chat start
+venice-py chat start
 
 # Single message
-venice chat start "Explain the theory of relativity"
+venice-py chat start "Explain the theory of relativity"
 
 # Choose a specific model
-venice chat start --model qwen3-235b "Summarize this article"
+venice-py chat start --model qwen3-235b "Summarize this article"
 
 # System prompt with custom temperature
-venice chat start --system "You are a Python tutor" --temperature 0.3
+venice-py chat start --system "You are a Python tutor" --temperature 0.3
 
 # Show reasoning process
-venice chat start --show-thinking "Solve: what is 23 * 47?"
+venice-py chat start --show-thinking "Solve: what is 23 * 47?"
 
 # Typewriter animation with stats
-venice chat start --animation typewriter --show-stats "Write a haiku"
+venice-py chat start --animation typewriter --show-stats "Write a haiku"
 
 # Web search enabled
-venice chat start --web-search on "What happened in tech news today?"
+venice-py chat start --web-search on "What happened in tech news today?"
 
 # Chat as a character
-venice chat start --character alan-watts "What is the meaning of life?"
+venice-py chat start --character alan-watts "What is the meaning of life?"
 
 # Reasoning model with effort control
-venice chat start --model deepseek-r1-0528 --reasoning-effort high "Prove P != NP"
+venice-py chat start --model deepseek-r1-0528 --reasoning-effort high "Prove P != NP"
 
 # Non-streaming JSON output (for scripting)
-venice chat start --no-stream --json-output "What is 2+2?"
+venice-py chat start --no-stream --json-output "What is 2+2?"
 
 # Save and resume conversations
-venice chat start --save "Tell me about quantum computing"
-venice chat start --continue-from last "What are its applications?"
+venice-py chat start --save "Tell me about quantum computing"
+venice-py chat start --continue-from last "What are its applications?"
 
 # Pipe input from stdin
-echo "Summarize this text" | venice chat start
-cat article.txt | venice chat start --model llama-3.3-70b "Summarize:"
+echo "Summarize this text" | venice-py chat start
+cat article.txt | venice-py chat start --model llama-3.3-70b "Summarize:"
 ```
 
-### `venice chat history`
+### `venice-py chat history`
 
 View and manage saved conversations.
 
 ```bash
-venice chat history [OPTIONS]
+venice-py chat history [OPTIONS]
 ```
 
 | Option | Default | Description |
@@ -252,13 +267,13 @@ venice chat history [OPTIONS]
 
 ```bash
 # List saved conversations
-venice chat history
+venice-py chat history
 
 # Export as JSON
-venice chat history --json
+venice-py chat history --json
 
 # Delete a conversation
-venice chat history --delete abc12345
+venice-py chat history --delete abc12345
 ```
 
 ---
@@ -267,12 +282,12 @@ venice chat history --delete abc12345
 
 Full-featured image generation, upscaling, editing, background removal, batch generation, style management, and presets.
 
-### `venice image generate`
+### `venice-py image generate`
 
 Generate an image from a text prompt.
 
 ```bash
-venice image generate [PROMPT] [OPTIONS]
+venice-py image generate [PROMPT] [OPTIONS]
 ```
 
 #### Options
@@ -287,7 +302,7 @@ venice image generate [PROMPT] [OPTIONS]
 | `--steps` | | model default | Inference steps (1–50, higher = better quality) |
 | `--cfg-scale` | | model default | CFG scale (0–20, higher = stricter prompt adherence) |
 | `--seed` | | random | Random seed for reproducibility |
-| `--style-preset` | `-sp` | — | Style preset to apply (see `venice image list-styles`) |
+| `--style-preset` | `-sp` | — | Style preset to apply (see `venice-py image list-styles`) |
 | `--lora-strength` | | — | LoRA strength 0–100 |
 | `--format` | | `png` | Output format: `jpeg`, `png`, `webp` |
 | `--aspect-ratio` | | — | Aspect ratio for the output (e.g. `1:1`, `16:9`) |
@@ -309,45 +324,45 @@ venice image generate [PROMPT] [OPTIONS]
 
 ```bash
 # Basic generation
-venice image generate "A serene mountain landscape at sunset"
+venice-py image generate "A serene mountain landscape at sunset"
 
 # Specific model and size
-venice image generate "Cyberpunk city" --model flux-dev --size 1280x720
+venice-py image generate "Cyberpunk city" --model flux-dev --size 1280x720
 
 # Fine-tuned generation
-venice image generate "Portrait of a scientist" \
+venice-py image generate "Portrait of a scientist" \
   --steps 40 --cfg-scale 7.5 --style-preset photographic \
   --format png --embed-exif
 
 # Reproducible generation with seed
-venice image generate "Cyberpunk cityscape" --seed 12345
+venice-py image generate "Cyberpunk cityscape" --seed 12345
 
 # Aspect ratio, high-resolution tier, and quality
-venice image generate "Editorial product shot" \
+venice-py image generate "Editorial product shot" \
   --aspect-ratio 16:9 --resolution 4K --quality high
 
 # Let the model pull in web search results
-venice image generate "Today's top headline as an infographic" --enable-web-search
+venice-py image generate "Today's top headline as an infographic" --enable-web-search
 
 # Multiple images
-venice image generate "Abstract art" --num-images 3 --save-dir ./art
+venice-py image generate "Abstract art" --num-images 3 --save-dir ./art
 
 # Using a preset
-venice image generate "Fantasy landscape" --preset photorealistic
+venice-py image generate "Fantasy landscape" --preset photorealistic
 
 # Interactive wizard
-venice image generate --interactive
+venice-py image generate --interactive
 
 # Open in viewer after generation
-venice image generate "Cute cat" --open
+venice-py image generate "Cute cat" --open
 ```
 
-### `venice image upscale`
+### `venice-py image upscale`
 
 Upscale an image using AI.
 
 ```bash
-venice image upscale <INPUT_FILE> [OPTIONS]
+venice-py image upscale <INPUT_FILE> [OPTIONS]
 ```
 
 | Option | Short | Default | Description |
@@ -362,17 +377,17 @@ venice image upscale <INPUT_FILE> [OPTIONS]
 | `--open` | | `false` | Open image after saving |
 
 ```bash
-venice image upscale photo.jpg --scale 2
-venice image upscale photo.png --scale 4 --enhance --save-dir ./upscaled
-venice image upscale logo.png --output logo_hd.png --open
+venice-py image upscale photo.jpg --scale 2
+venice-py image upscale photo.png --scale 4 --enhance --save-dir ./upscaled
+venice-py image upscale logo.png --output logo_hd.png --open
 ```
 
-### `venice image edit`
+### `venice-py image edit`
 
 Edit an image using a text prompt.
 
 ```bash
-venice image edit <INPUT_FILE> --prompt <INSTRUCTION> [OPTIONS]
+venice-py image edit <INPUT_FILE> --prompt <INSTRUCTION> [OPTIONS]
 ```
 
 | Option | Short | Default | Description |
@@ -391,20 +406,20 @@ venice image edit <INPUT_FILE> --prompt <INSTRUCTION> [OPTIONS]
 > `--output-format` is sent to the API and sets the real encoding; `--format` only hints the saved filename extension. When both are given, `--output-format` wins for the extension too.
 
 ```bash
-venice image edit photo.jpg --prompt "Add a rainbow to the sky"
-venice image edit portrait.png --prompt "Change hair color to red"
-venice image edit scene.jpg -p "Make it nighttime" --format png --open
-venice image edit photo.jpg -p "Editorial retouch" \
+venice-py image edit photo.jpg --prompt "Add a rainbow to the sky"
+venice-py image edit portrait.png --prompt "Change hair color to red"
+venice-py image edit scene.jpg -p "Make it nighttime" --format png --open
+venice-py image edit photo.jpg -p "Editorial retouch" \
   --aspect-ratio 16:9 --resolution 4K --output-format jpeg
-venice image edit photo.jpg -p "Add a rainbow" --no-safe-mode
+venice-py image edit photo.jpg -p "Add a rainbow" --no-safe-mode
 ```
 
-### `venice image multi-edit`
+### `venice-py image multi-edit`
 
 Edit an image using up to three layered inputs. The first image is the base; additional images are layered on top, guided by a single prompt.
 
 ```bash
-venice image multi-edit --prompt <INSTRUCTION> --image <BASE_FILE> [OPTIONS]
+venice-py image multi-edit --prompt <INSTRUCTION> --image <BASE_FILE> [OPTIONS]
 ```
 
 | Option | Short | Default | Description |
@@ -423,18 +438,18 @@ venice image multi-edit --prompt <INSTRUCTION> --image <BASE_FILE> [OPTIONS]
 | `--open` | | `false` | Open image after saving |
 
 ```bash
-venice image multi-edit --prompt "Combine these into one scene" --image base.png
-venice image multi-edit -p "Blend the overlay onto the base" -i base.png --image-2 overlay.png
-venice image multi-edit -p "Composite three layers" -i base.png --image-2 mid.png --image-3 top.png \
+venice-py image multi-edit --prompt "Combine these into one scene" --image base.png
+venice-py image multi-edit -p "Blend the overlay onto the base" -i base.png --image-2 overlay.png
+venice-py image multi-edit -p "Composite three layers" -i base.png --image-2 mid.png --image-3 top.png \
   --output-format png --quality high
 ```
 
-### `venice image remove-bg`
+### `venice-py image remove-bg`
 
 Remove the background from an image (returns transparent PNG by default).
 
 ```bash
-venice image remove-bg <INPUT_FILE> [OPTIONS]
+venice-py image remove-bg <INPUT_FILE> [OPTIONS]
 ```
 
 | Option | Short | Default | Description |
@@ -445,17 +460,17 @@ venice image remove-bg <INPUT_FILE> [OPTIONS]
 | `--open` | | `false` | Open image after saving |
 
 ```bash
-venice image remove-bg photo.jpg
-venice image remove-bg product.png --save-dir ./cutouts --open
-venice image remove-bg headshot.jpg --output headshot_nobg.png
+venice-py image remove-bg photo.jpg
+venice-py image remove-bg product.png --save-dir ./cutouts --open
+venice-py image remove-bg headshot.jpg --output headshot_nobg.png
 ```
 
-### `venice image batch`
+### `venice-py image batch`
 
 Generate multiple images from a file of prompts (one prompt per line).
 
 ```bash
-venice image batch --prompts-file <FILE> [OPTIONS]
+venice-py image batch --prompts-file <FILE> [OPTIONS]
 ```
 
 | Option | Short | Default | Description |
@@ -484,25 +499,25 @@ A peaceful English garden in spring
 EOF
 
 # Generate all with consistent style
-venice image batch --prompts-file prompts.txt --style-preset cinematic --steps 30
+venice-py image batch --prompts-file prompts.txt --style-preset cinematic --steps 30
 ```
 
-### `venice image list-styles`
+### `venice-py image list-styles`
 
 List all available style presets from the API.
 
 ```bash
-venice image list-styles
+venice-py image list-styles
 ```
 
 Common styles include: `photographic`, `cinematic`, `anime`, `fantasy-art`, `digital-art`, `3d-model`, `pixel-art`, and more.
 
-### `venice image presets`
+### `venice-py image presets`
 
 Launch the interactive preset manager. Create, view, and delete image generation presets.
 
 ```bash
-venice image presets
+venice-py image presets
 ```
 
 The interactive menu offers:
@@ -526,10 +541,10 @@ Custom presets are stored in `~/.venice/presets/` as JSON files.
 
 ```bash
 # Apply a preset during generation
-venice image generate "Portrait photo" --preset photorealistic
+venice-py image generate "Portrait photo" --preset photorealistic
 
 # Override specific preset values
-venice image generate "Abstract art" --preset artistic --steps 40
+venice-py image generate "Abstract art" --preset artistic --steps 40
 ```
 
 ---
@@ -538,12 +553,12 @@ venice image generate "Abstract art" --preset artistic --steps 40
 
 Text-to-speech and speech-to-text capabilities.
 
-### `venice audio speak`
+### `venice-py audio speak`
 
 Convert text to speech.
 
 ```bash
-venice audio speak [TEXT] [OPTIONS]
+venice-py audio speak [TEXT] [OPTIONS]
 ```
 
 | Option | Short | Default | Description |
@@ -559,25 +574,25 @@ venice audio speak [TEXT] [OPTIONS]
 
 ```bash
 # Basic text-to-speech
-venice audio speak "Hello, welcome to Venice AI!"
+venice-py audio speak "Hello, welcome to Venice AI!"
 
 # Custom voice and format
-venice audio speak "Good morning" --voice af_heart --format wav
+venice-py audio speak "Good morning" --voice af_heart --format wav
 
 # Adjust speed and save location
-venice audio speak "This is a fast narration" --speed 1.5 --output narration.mp3
+venice-py audio speak "This is a fast narration" --speed 1.5 --output narration.mp3
 
 # Pipe text from stdin
-echo "Read this aloud" | venice audio speak
-cat script.txt | venice audio speak --output script_audio.mp3
+echo "Read this aloud" | venice-py audio speak
+cat script.txt | venice-py audio speak --output script_audio.mp3
 ```
 
-### `venice audio transcribe`
+### `venice-py audio transcribe`
 
 Transcribe audio to text.
 
 ```bash
-venice audio transcribe <FILE> [OPTIONS]
+venice-py audio transcribe <FILE> [OPTIONS]
 ```
 
 | Option | Short | Default | Description |
@@ -592,28 +607,28 @@ venice audio transcribe <FILE> [OPTIONS]
 
 ```bash
 # Basic transcription
-venice audio transcribe recording.mp3
+venice-py audio transcribe recording.mp3
 
 # With language hint and timestamps
-venice audio transcribe meeting.wav --language en --timestamps
+venice-py audio transcribe meeting.wav --language en --timestamps
 
 # Save to file
-venice audio transcribe interview.mp3 --output transcript.txt
+venice-py audio transcribe interview.mp3 --output transcript.txt
 
 # JSON output
-venice audio transcribe audio.mp3 --format json
+venice-py audio transcribe audio.mp3 --format json
 ```
 
-### `venice audio voices`
+### `venice-py audio voices`
 
 List available TTS voices. Wraps `Audio.get_voices()`. Supports filtering
 by gender, region, and model.
 
 ```bash
-venice audio voices
-venice audio voices --gender female
-venice audio voices --region af --json
-venice audio voices --model tts-kokoro
+venice-py audio voices
+venice-py audio voices --gender female
+venice-py audio voices --region af --json
+venice-py audio voices --model tts-kokoro
 ```
 
 ---
@@ -622,12 +637,12 @@ venice audio voices --model tts-kokoro
 
 Generate videos from text prompts or animate existing images. Video generation is asynchronous — jobs are queued and polled until complete.
 
-### `venice video generate`
+### `venice-py video generate`
 
 Generate a video from a text prompt.
 
 ```bash
-venice video generate <PROMPT> [OPTIONS]
+venice-py video generate <PROMPT> [OPTIONS]
 ```
 
 | Option | Short | Default | Description |
@@ -653,32 +668,32 @@ venice video generate <PROMPT> [OPTIONS]
 
 ```bash
 # Basic video generation
-venice video generate "A sunset over the ocean with gentle waves"
+venice-py video generate "A sunset over the ocean with gentle waves"
 
 # Custom duration and aspect ratio
-venice video generate "A cat playing piano" --duration 10s --aspect-ratio 1:1
+venice-py video generate "A cat playing piano" --duration 10s --aspect-ratio 1:1
 
 # Cinematic high-res
-venice video generate "Cinematic drone shot over mountains" --resolution 1080p
+venice-py video generate "Cinematic drone shot over mountains" --resolution 1080p
 
 # Queue without waiting
-venice video generate "Quick preview scene" --no-poll
+venice-py video generate "Quick preview scene" --no-poll
 
 # Reference images for character consistency, plus audio
-venice video generate "She walks toward the camera" \
+venice-py video generate "She walks toward the camera" \
   --audio --reference-image-urls https://example.com/ref1.png
 
 # Transition to an end frame
-venice video generate "Morning to night timelapse" \
+venice-py video generate "Morning to night timelapse" \
   --end-image-url https://example.com/night.png
 ```
 
-### `venice video from-image`
+### `venice-py video from-image`
 
 Animate an image into a video. The prompt describes the desired motion, not the image content.
 
 ```bash
-venice video from-image <INPUT_FILE> [OPTIONS]
+venice-py video from-image <INPUT_FILE> [OPTIONS]
 ```
 
 | Option | Short | Default | Description |
@@ -703,21 +718,21 @@ venice video from-image <INPUT_FILE> [OPTIONS]
 
 ```bash
 # Animate an image with default motion
-venice video from-image landscape.jpg
+venice-py video from-image landscape.jpg
 
 # Describe the motion
-venice video from-image photo.png --prompt "Gentle breeze through the trees"
+venice-py video from-image photo.png --prompt "Gentle breeze through the trees"
 
 # Longer duration
-venice video from-image portrait.jpg --duration 10s --open
+venice-py video from-image portrait.jpg --duration 10s --open
 ```
 
-### `venice video status`
+### `venice-py video status`
 
 Check the status of a video generation job (useful with `--no-poll`).
 
 ```bash
-venice video status <JOB_ID> [OPTIONS]
+venice-py video status <JOB_ID> [OPTIONS]
 ```
 
 | Option | Short | Default | Description |
@@ -727,8 +742,8 @@ venice video status <JOB_ID> [OPTIONS]
 > No default is applied here; pass the same model the job was queued with.
 
 ```bash
-venice video status abc123
-venice video status abc123 --model wan-2.6-image-to-video
+venice-py video status abc123
+venice-py video status abc123 --model wan-2.6-image-to-video
 ```
 
 ---
@@ -737,12 +752,12 @@ venice video status abc123 --model wan-2.6-image-to-video
 
 Browse and inspect pre-configured AI personalities and specialized assistants.
 
-### `venice characters list`
+### `venice-py characters list`
 
 List available AI characters.
 
 ```bash
-venice characters list [OPTIONS]
+venice-py characters list [OPTIONS]
 ```
 
 | Option | Default | Description |
@@ -761,20 +776,20 @@ venice characters list [OPTIONS]
 | `--model-id` | — | Filter by model ID |
 
 ```bash
-venice characters list
-venice characters list --search coding
-venice characters list --sort-by highlyRated --limit 20
-venice characters list --tags philosophy --web-enabled
-venice characters list --categories education
-venice characters list --json
+venice-py characters list
+venice-py characters list --search coding
+venice-py characters list --sort-by highlyRated --limit 20
+venice-py characters list --tags philosophy --web-enabled
+venice-py characters list --categories education
+venice-py characters list --json
 ```
 
-### `venice characters info`
+### `venice-py characters info`
 
 Show detailed information about a specific character.
 
 ```bash
-venice characters info <SLUG> [OPTIONS]
+venice-py characters info <SLUG> [OPTIONS]
 ```
 
 | Option | Default | Description |
@@ -784,22 +799,22 @@ venice characters info <SLUG> [OPTIONS]
 The human-readable view shows the slug, model, description, tags, adult/web flags, import count, and timestamps. `--json` emits the full record — `id`, `author`, `featured`, `isOwner`, `shareUrl`, `photoUrl`, `createdAt`/`updatedAt`, and a nested `stats` object (`imports`, `averageRating`, `ratingCount`, `ratingSum`, `userRating`).
 
 ```bash
-venice characters info alan-watts
-venice characters info alan-watts --json
+venice-py characters info alan-watts
+venice-py characters info alan-watts --json
 ```
 
 Use a character in chat with `--character`:
 
 ```bash
-venice chat start --character alan-watts "What is the meaning of life?"
+venice-py chat start --character alan-watts "What is the meaning of life?"
 ```
 
-### `venice characters reviews`
+### `venice-py characters reviews`
 
 Show public reviews for a character.
 
 ```bash
-venice characters reviews <SLUG> [OPTIONS]
+venice-py characters reviews <SLUG> [OPTIONS]
 ```
 
 | Option | Default | Description |
@@ -811,9 +826,9 @@ venice characters reviews <SLUG> [OPTIONS]
 The summary line reports the average rating and total review count; each review shows its rating, creation date, and message.
 
 ```bash
-venice characters reviews alan-watts
-venice characters reviews alan-watts --page 2 --page-size 50
-venice characters reviews alan-watts --json
+venice-py characters reviews alan-watts
+venice-py characters reviews alan-watts --page 2 --page-size 50
+venice-py characters reviews alan-watts --json
 ```
 
 ---
@@ -823,7 +838,7 @@ venice characters reviews alan-watts --json
 Generate text embeddings for semantic analysis, similarity search, and clustering.
 
 ```bash
-venice embeddings [TEXT] [OPTIONS]
+venice-py embeddings [TEXT] [OPTIONS]
 ```
 
 | Option | Short | Default | Description |
@@ -838,19 +853,19 @@ venice embeddings [TEXT] [OPTIONS]
 
 ```bash
 # Generate embeddings
-venice embeddings "The quick brown fox"
+venice-py embeddings "The quick brown fox"
 
 # Full JSON output with vector
-venice embeddings "Hello world" --json
+venice-py embeddings "Hello world" --json
 
 # Save to file
-venice embeddings "Some text" --output embeddings.json
+venice-py embeddings "Some text" --output embeddings.json
 
 # Pipe text from stdin
-echo "Embed this text" | venice embeddings
+echo "Embed this text" | venice-py embeddings
 
 # Custom dimensions
-venice embeddings "Search query" --dimensions 256
+venice-py embeddings "Search query" --dimensions 256
 ```
 
 ---
@@ -860,7 +875,7 @@ venice embeddings "Search query" --dimensions 256
 List, filter, compare, and inspect available AI models. The `models` command supports extensive filtering by type, capabilities, price, and status.
 
 ```bash
-venice models [OPTIONS]
+venice-py models [OPTIONS]
 ```
 
 ### Display Options
@@ -930,40 +945,40 @@ venice models [OPTIONS]
 
 ```bash
 # List all models
-venice models
+venice-py models
 
 # Text models only, sorted by price
-venice models --type text --sort price-asc
+venice-py models --type text --sort price-asc
 
 # Image models
-venice models --type image
+venice-py models --type image
 
 # Models with vision and function calling
-venice models --vision --function-calling
+venice-py models --vision --function-calling
 
 # Budget-friendly models under $1/M tokens
-venice models --budget 1.0
+venice-py models --budget 1.0
 
 # Exclude beta models
-venice models --no-beta
+venice-py models --no-beta
 
 # Search for a model
-venice models --search "llama"
+venice-py models --search "llama"
 
 # Detailed view of a specific model
-venice models --id qwen3-235b
+venice-py models --id qwen3-235b
 
 # Compare two models side-by-side
-venice models --compare "qwen3-235b,llama-3.3-70b"
+venice-py models --compare "qwen3-235b,llama-3.3-70b"
 
 # JSON output for scripting
-venice models --json
+venice-py models --json
 
 # Verbose listing with full per-model detail
-venice models --verbose
+venice-py models --verbose
 ```
 
-### `venice models resolve`
+### `venice-py models resolve`
 
 Auto-pick a model by type and capabilities. Wraps
 `Models.resolve()` and the ten typed `resolve_*()` helpers
@@ -972,30 +987,30 @@ scripts when you want "the cheapest model that supports vision + function
 calling" without hardcoding a specific model ID.
 
 ```bash
-venice models resolve --type chat --function-calling
-venice models resolve --type image
-venice models resolve --type chat --vision --min-context-tokens 32000
+venice-py models resolve --type chat --function-calling
+venice-py models resolve --type image
+venice-py models resolve --type chat --vision --min-context-tokens 32000
 ```
 
-### `venice models get`
+### `venice-py models get`
 
 Show the full model record for a single ID. Wraps `Models.get()`. Pass
 `--json` for machine-readable output.
 
 ```bash
-venice models get llama-3.3-70b
-venice models get qwen3-235b --json
+venice-py models get llama-3.3-70b
+venice-py models get qwen3-235b --json
 ```
 
-### `venice models capabilities`
+### `venice-py models capabilities`
 
 Show the structured `Capabilities` for a single model
 (`Models.get_capabilities()`). Includes function-calling, vision,
 reasoning, web-search, code, response-schema, and TEE/e2ee flags.
 
 ```bash
-venice models capabilities llama-3.3-70b
-venice models capabilities qwen3-235b --json
+venice-py models capabilities llama-3.3-70b
+venice-py models capabilities qwen3-235b --json
 ```
 
 ---
@@ -1004,12 +1019,12 @@ venice models capabilities qwen3-235b --json
 
 View account billing information and usage statistics.
 
-### `venice account balance`
+### `venice-py account balance`
 
 Show current account balance and credits.
 
 ```bash
-venice account balance [OPTIONS]
+venice-py account balance [OPTIONS]
 ```
 
 | Option | Default | Description |
@@ -1017,16 +1032,16 @@ venice account balance [OPTIONS]
 | `--json` | `false` | Output as JSON |
 
 ```bash
-venice account balance
-venice account balance --json
+venice-py account balance
+venice-py account balance --json
 ```
 
-### `venice account usage`
+### `venice-py account usage`
 
 Show usage statistics for your account. Displays billing entries, costs, and a breakdown by product SKU.
 
 ```bash
-venice account usage [OPTIONS]
+venice-py account usage [OPTIONS]
 ```
 
 | Option | Default | Description |
@@ -1037,24 +1052,24 @@ venice account usage [OPTIONS]
 | `--currency` | — | Filter entries by currency: `USD`, `DIEM`, `VCU`, `BUNDLED_CREDITS` |
 
 ```bash
-venice account usage
-venice account usage --start-date 2025-01-01 --end-date 2025-02-01
-venice account usage --currency USD
-venice account usage --json
+venice-py account usage
+venice-py account usage --start-date 2025-01-01 --end-date 2025-02-01
+venice-py account usage --currency USD
+venice-py account usage --json
 ```
 
-### `venice account keys get`
+### `venice-py account keys get`
 
 Retrieve a single API key by ID. Wraps `client.api_keys.retrieve()`. The
-top-level `venice api-keys` group covers list/create/delete; the
+top-level `venice-py api-keys` group covers list/create/delete; the
 `account keys` subgroup adds the single-key retrieve / update surface.
 
 ```bash
-venice account keys get key_abc123
-venice account keys get key_abc123 --json
+venice-py account keys get key_abc123
+venice-py account keys get key_abc123 --json
 ```
 
-### `venice account keys update`
+### `venice-py account keys update`
 
 Update an existing API key. Wraps `client.api_keys.update()`. At least one
 of `--description`, `--expiry`, `--limit-usd`, `--limit-diem`, `--limit-vcu`,
@@ -1071,13 +1086,13 @@ or `--limit-period` must be provided.
 | `--json` | Output JSON |
 
 ```bash
-venice account keys update key_abc123 --description "Production"
-venice account keys update key_abc123 --expiry 2026-12-31
-venice account keys update key_abc123 --limit-usd 50 --limit-diem 5
-venice account keys update key_abc123 --limit-period MONTH
+venice-py account keys update key_abc123 --description "Production"
+venice-py account keys update key_abc123 --expiry 2026-12-31
+venice-py account keys update key_abc123 --limit-usd 50 --limit-diem 5
+venice-py account keys update key_abc123 --limit-period MONTH
 ```
 
-### `venice account keys rate-limits`
+### `venice-py account keys rate-limits`
 
 Show the current rate limits (per-model RPM / RPD / TPM) for your API key.
 Wraps `client.api_keys.get_rate_limits()`. The header reports your API tier,
@@ -1088,11 +1103,11 @@ whether access is permitted, and when the next epoch begins.
 | `--json` | `false` | Output as JSON |
 
 ```bash
-venice account keys rate-limits
-venice account keys rate-limits --json
+venice-py account keys rate-limits
+venice-py account keys rate-limits --json
 ```
 
-### `venice account keys rate-limit-logs`
+### `venice-py account keys rate-limit-logs`
 
 Show the most recent rate-limit violations for your account (up to 50).
 Wraps `client.api_keys.get_rate_limit_logs()`. Each entry lists a timestamp,
@@ -1103,8 +1118,8 @@ model, limit type, and tier.
 | `--json` | `false` | Output as JSON |
 
 ```bash
-venice account keys rate-limit-logs
-venice account keys rate-limit-logs --json
+venice-py account keys rate-limit-logs
+venice-py account keys rate-limit-logs --json
 ```
 
 ---
@@ -1113,12 +1128,12 @@ venice account keys rate-limit-logs --json
 
 Manage your Venice AI API keys. List, create, and delete keys for your account.
 
-### `venice api-keys list`
+### `venice-py api-keys list`
 
 List all API keys.
 
 ```bash
-venice api-keys list [OPTIONS]
+venice-py api-keys list [OPTIONS]
 ```
 
 | Option | Default | Description |
@@ -1126,16 +1141,16 @@ venice api-keys list [OPTIONS]
 | `--json` | `false` | Output as JSON |
 
 ```bash
-venice api-keys list
-venice api-keys list --json
+venice-py api-keys list
+venice-py api-keys list --json
 ```
 
-### `venice api-keys create`
+### `venice-py api-keys create`
 
 Create a new API key. The secret key is only shown once — save it immediately.
 
 ```bash
-venice api-keys create --name <NAME> [OPTIONS]
+venice-py api-keys create --name <NAME> [OPTIONS]
 ```
 
 | Option | Default | Description |
@@ -1150,19 +1165,19 @@ venice api-keys create --name <NAME> [OPTIONS]
 | `--json` | `false` | Output as JSON |
 
 ```bash
-venice api-keys create --name "Production Key"
-venice api-keys create --name "Admin" --type ADMIN
-venice api-keys create --name "Capped" --limit-usd 50 --limit-period MONTH
-venice api-keys create --name "Expiring" --expiry 2026-12-31
-venice api-keys create --name "CI/CD Pipeline" --json
+venice-py api-keys create --name "Production Key"
+venice-py api-keys create --name "Admin" --type ADMIN
+venice-py api-keys create --name "Capped" --limit-usd 50 --limit-period MONTH
+venice-py api-keys create --name "Expiring" --expiry 2026-12-31
+venice-py api-keys create --name "CI/CD Pipeline" --json
 ```
 
-### `venice api-keys delete`
+### `venice-py api-keys delete`
 
 Delete an API key. Prompts for confirmation before deletion.
 
 ```bash
-venice api-keys delete <KEY_ID> [OPTIONS]
+venice-py api-keys delete <KEY_ID> [OPTIONS]
 ```
 
 | Option | Short | Default | Description |
@@ -1170,17 +1185,17 @@ venice api-keys delete <KEY_ID> [OPTIONS]
 | `--yes` | `-y` | `false` | Skip the confirmation prompt (for scripting / CI) |
 
 ```bash
-venice api-keys delete key_abc123
+venice-py api-keys delete key_abc123
 
 # Non-interactive deletion (no confirmation prompt)
-venice api-keys delete key_abc123 --yes
+venice-py api-keys delete key_abc123 --yes
 ```
 
 ---
 
 ## Lint
 
-`venice lint <path>` walks Python source files and flags v1 / OpenAI-style / non-idiomatic patterns that won't work or work sub-optimally on Venice SDK v2 — `AsyncVeniceClient` imports, hardcoded model IDs, `max_tokens=` kwargs, `PaymentRequiredError.payment_instructions` accesses, and a dozen others.
+`venice-py lint <path>` walks Python source files and flags v1 / OpenAI-style / non-idiomatic patterns that won't work or work sub-optimally on Venice SDK v2 — `AsyncVeniceClient` imports, hardcoded model IDs, `max_tokens=` kwargs, `PaymentRequiredError.payment_instructions` accesses, and a dozen others.
 
 Output is in flake8-compatible `path:line:col: CODE message` format, suitable for editor integrations and CI pipelines.
 
@@ -1188,16 +1203,16 @@ Output is in flake8-compatible `path:line:col: CODE message` format, suitable fo
 
 ```bash
 # Lint a directory tree
-venice lint src/
+venice-py lint src/
 
 # Lint a single file
-venice lint path/to/script.py
+venice-py lint path/to/script.py
 
 # Treat informational findings (V401) as errors — exit 1 if any are present
-venice lint --strict src/
+venice-py lint --strict src/
 
 # Filter to specific rule codes
-venice lint --code V100 --code V200 src/
+venice-py lint --code V100 --code V200 src/
 ```
 
 ### Exit codes
@@ -1232,23 +1247,23 @@ The lint runs entirely on AST — no execution of user code. Use it as a pre-com
 
 ## Health
 
-`venice health` runs a sequence of small checks against the Venice API and reports each one. Use it after configuring a fresh environment, when something feels off, or as a CI smoke test.
+`venice-py health` runs a sequence of small checks against the Venice API and reports each one. Use it after configuring a fresh environment, when something feels off, or as a CI smoke test.
 
 ### Quick examples
 
 ```bash
 # Default checks: API key, models catalog, billing balance
-venice health
+venice-py health
 
 # Add a tiny embedding ping (small cost, typically <$0.001)
-venice health --full
+venice-py health --full
 
 # Add an x402 prepaid-ledger balance read using a wallet env var
-venice health --wallet                                  # default env var: VENICE_X402_TEST_PRIVATE_KEY
-venice health --wallet --wallet-env MY_WALLET_KEY       # custom env var
+venice-py health --wallet                                  # default env var: VENICE_X402_TEST_PRIVATE_KEY
+venice-py health --wallet --wallet-env MY_WALLET_KEY       # custom env var
 
 # Combine
-venice health --full --wallet
+venice-py health --full --wallet
 ```
 
 ### Default checks
@@ -1274,7 +1289,7 @@ venice health --full --wallet
 ### Sample output
 
 ```
-ℹ️  venice health
+ℹ️  venice-py health
   ✓ api_key                  present (vn_a…fde9)
   ✓ models.list              78 text models reachable
   ✓ billing.get_balance      USD $35.71774095 / DIEM 0.7503080828059601
@@ -1324,16 +1339,16 @@ Chat, audio speak, and embeddings support piped input:
 
 ```bash
 # Pipe text to chat
-echo "Summarize this in one sentence" | venice chat start
+echo "Summarize this in one sentence" | venice-py chat start
 
 # Pipe a file to chat
-cat README.md | venice chat start "Summarize this document"
+cat README.md | venice-py chat start "Summarize this document"
 
 # Pipe text to TTS
-echo "Hello world" | venice audio speak --output greeting.mp3
+echo "Hello world" | venice-py audio speak --output greeting.mp3
 
 # Pipe text to embeddings
-echo "Semantic search query" | venice embeddings --json
+echo "Semantic search query" | venice-py embeddings --json
 ```
 
 ### JSON Output for Scripting
@@ -1342,19 +1357,19 @@ Most commands support `--json` for machine-readable output:
 
 ```bash
 # Get model list as JSON
-venice models --json | jq '.[] | .id'
+venice-py models --json | jq '.[] | .id'
 
 # Get account balance as JSON
-venice account balance --json | jq '.balances.usd'
+venice-py account balance --json | jq '.balances.usd'
 
 # Get character list as JSON
-venice characters list --json | jq '.[].slug'
+venice-py characters list --json | jq '.[].slug'
 
 # Get API keys as JSON
-venice api-keys list --json
+venice-py api-keys list --json
 
 # Chat with JSON response
-venice chat start --no-stream --json-output "What is 2+2?"
+venice-py chat start --no-stream --json-output "What is 2+2?"
 ```
 
 ### Combining Plain Mode with Pipelines
@@ -1394,7 +1409,7 @@ venice --plain audio speak "Welcome to our app" --output welcome.mp3 --save-dir 
 ```bash
 export VENICE_API_KEY="your-key"
 # or
-venice configure
+venice-py configure
 ```
 
 ### Module Not Found
@@ -1407,16 +1422,16 @@ pip install 'venice-ai[cli]>=2'
 
 ```bash
 # If using Poetry
-poetry run venice --help
+poetry run venice-py --help
 
 # Or activate the virtual environment
 poetry shell
-venice --help
+venice-py --help
 ```
 
 ### Model Not Found
 
-Run `venice models` to see available models. Use `venice models --type text` or `venice models --type image` to filter by type. Model IDs must match exactly.
+Run `venice-py models` to see available models. Use `venice-py models --type text` or `venice-py models --type image` to filter by type. Model IDs must match exactly.
 
 ---
 


### PR DESCRIPTION
## The collision

Venice's official CLI ([`veniceai-cli`](https://www.npmjs.com/package/veniceai-cli)) installs a binary named `venice`. As of v2.0.0, so did this SDK's `[cli]` extra:

```
npm i -g veniceai-cli          →  bin: { "venice": "dist/index.js" }
pip install 'venice-ai[cli]'   →  console_scripts: venice=venice_ai.cli:cli
```

Which one runs depends on `PATH` order, so it flips depending on whether a virtualenv is active. Because the two share subcommand names — `chat`, `image`, `video`, `embeddings`, `models`, `characters`, `config`/`configure`, `completion` — the shadowing is silent: `venice chat "hi"` doesn't error, it runs the *other* CLI and rejects the flags.

Same failure class as the pip-resolver fallback fixed in 2.0.2: the wrong thing runs without saying so.

## Scope

`venice` → `venice-py` across ~480 references in 49 tracked files: README, docs site, bundled Claude Code skills (shipped package data, so this reaches users' Claude Code), source docstrings that surface as `--help`, tests, and `tools/cli_parity_check.py`.

Rewrites were anchored on `venice <known-subcommand>`, leaving prose, `VENICE_API_KEY`, `venice.ai` URLs, the `venice-ai` package name, and the skills' natural-language triggers (`venice rate limit`, `venice x402`) untouched.

**Not a pure string swap:** the `completion` command built its env var as `prog_name.upper()`, which would have produced `_VENICE-PY_COMPLETE` — not a legal shell variable name. It now strips hyphens first, yielding `_VENICE_PY_COMPLETE`.

**CHANGELOG history is deliberately unchanged.** Those entries describe what shipped at the time; rewriting them would make them inaccurate.

## Upgrade hazard, documented

Upgrading in place does not delete the old script — verified locally, where a stale `venice` still reported `Venice AI CLI v2.0.0` after the rename. The 2.1.0 notes, the CLI reference, and the README all tell users to remove it with `rm "$(command -v venice)"`.

## Verification

- `poetry run venice-py --version` → `Venice AI CLI v2.1.0`
- `venice-py completion bash` emits `_VENICE_PY_COMPLETE`
- built wheel ships `venice-py=venice_ai.cli:cli`
- `tests/cli`: **1374 passed**
- `make lint`, `make skills-check`: clean

Version: **2.1.0** — minor, since it removes a two-day-old console script rather than changing the library API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)