### PR TITLE
fix(website): clear the uuid advisory with a version-keyed override

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -18860,13 +18860,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/website/package.json
+++ b/website/package.json
@@ -38,7 +38,8 @@
   "overrides": {
     "serialize-javascript": "^7.0.5",
     "minimatch@9.0.3": "9.0.9",
-    "yaml@2.8.1": "2.9.0"
+    "yaml@2.8.1": "2.9.0",
+    "uuid@8.3.2": "11.1.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Closes the one fixable Dependabot alert on `main`. The other two are unfixable upstream — analysis below.

### What was fixed

`GHSA-w5hq-g745-h8pq` — `uuid < 11.1.1`, missing buffer bounds check in `v3/v5/v6` when `buf` is provided.

It reaches the tree through `sockjs` → `webpack-dev-server` → `@docusaurus/core`, so it only ever loads on `npm start` and never appears in the deployed build. Clearing it is still worth doing: the pinned 8.3.2 carried an upstream deprecation notice recommending **uuid@11 for exactly this case, a CommonJS consumer**.

### Why the override is keyed on a version

```json
"uuid@8.3.2": "11.1.1"
```

not a bare `"uuid"`. A parent-scoped override collapses *every* copy in the tree onto one version — that has already bitten this repo once, silently retargeting an exactly-pinned nested dependency. The version-keyed form patches only the copy that is actually vulnerable, and it matches the existing `minimatch@9.0.3` and `yaml@2.8.1` entries.

**Verified the blast radius**: the lockfile diff is 8 insertions / 5 deletions touching `uuid` and nothing else. `minimatch` (both the 3.1.5 top-level and the 9.0.9 nested pin), `yaml` 2.9.0 and `serialize-javascript` 7.1.0 all hold.

### Verification

- `sockjs` still requires uuid 11 and constructs a server — the one consumer that could have broken
- `npm run build` passes under `onBrokenLinks: 'throw'`, 82 documents processed
- `tsc` clean
- `uuid` no longer appears in `npm audit`

### The two remaining high alerts have no fix

`GHSA-w3rx-r6r6-pgpr` and `GHSA-5p2g-fcmc-qvqq` — `image-size <= 2.0.2`, DoS via infinite loops in the ICNS and JXL/HEIF parsers.

**2.0.2 is the latest published version.** There is no fix to take, and npm agrees (`fixAvailable: false`). It arrives via `@docusaurus/mdx-loader` as a build-time loader that measures images committed to this repo, so reaching the vulnerable parsers requires already being able to commit here. The other 16 entries `npm audit` reports are transitive fan-out from this single root, not separate problems.

Nothing to do until upstream ships a patched `image-size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)