### PR TITLE
chore: repoint every repository URL at sethbang/venice-py

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,9 +70,21 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+        # The key is namespaced by repository on purpose. `virtualenvs-in-project`
+        # puts .venv inside the workspace, and a virtualenv bakes absolute paths
+        # into pyvenv.cfg, bin/activate and every console-script shebang. Renaming
+        # the repo moves the workspace (/home/runner/work/<repo>/<repo>), so a
+        # cache restored across a rename yields a .venv whose interpreter path no
+        # longer exists. Poetry still reports "No dependencies to install or
+        # update" — the dist-info metadata is all there — and the failure surfaces
+        # later as `Command not found` from poetry run. actions/cache does not
+        # re-save on a hit, so without the repository in the key that broken venv
+        # would be restored forever.
+          # restore-keys is namespaced too: a bare prefix would fall back to the
+          # pre-rename cache and reintroduce the same broken venv.
+          key: ${{ github.repository }}-${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
-            ${{ runner.os }}-poetry-
+            ${{ github.repository }}-${{ runner.os }}-poetry-
       
       - name: Install dependencies
         run: poetry install --with dev
@@ -166,9 +178,21 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+        # The key is namespaced by repository on purpose. `virtualenvs-in-project`
+        # puts .venv inside the workspace, and a virtualenv bakes absolute paths
+        # into pyvenv.cfg, bin/activate and every console-script shebang. Renaming
+        # the repo moves the workspace (/home/runner/work/<repo>/<repo>), so a
+        # cache restored across a rename yields a .venv whose interpreter path no
+        # longer exists. Poetry still reports "No dependencies to install or
+        # update" — the dist-info metadata is all there — and the failure surfaces
+        # later as `Command not found` from poetry run. actions/cache does not
+        # re-save on a hit, so without the repository in the key that broken venv
+        # would be restored forever.
+          # restore-keys is namespaced too: a bare prefix would fall back to the
+          # pre-rename cache and reintroduce the same broken venv.
+          key: ${{ github.repository }}-${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
-            ${{ runner.os }}-poetry-
+            ${{ github.repository }}-${{ runner.os }}-poetry-
       
       - name: Install dependencies
         run: poetry install --with dev

--- a/.github/workflows/publish-testpypi.yaml
+++ b/.github/workflows/publish-testpypi.yaml
@@ -10,7 +10,7 @@
 #   2. Add a new pending publisher with:
 #        - PyPI Project Name:    venice-py
 #        - Owner:                sethbang
-#        - Repository name:      venice-ai   (update if the repo is ever renamed)
+#        - Repository name:      venice-py   (update if the repo is ever renamed)
 #        - Workflow name:        publish-testpypi.yaml
 #        - Environment name:     testpypi
 #   3. Save. A pending publisher becomes a real one on the first

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -35,7 +35,17 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+        # The key is namespaced by repository on purpose. `virtualenvs-in-project`
+        # puts .venv inside the workspace, and a virtualenv bakes absolute paths
+        # into pyvenv.cfg, bin/activate and every console-script shebang. Renaming
+        # the repo moves the workspace (/home/runner/work/<repo>/<repo>), so a
+        # cache restored across a rename yields a .venv whose interpreter path no
+        # longer exists. Poetry still reports "No dependencies to install or
+        # update" — the dist-info metadata is all there — and the failure surfaces
+        # later as `Command not found` from poetry run. actions/cache does not
+        # re-save on a hit, so without the repository in the key that broken venv
+        # would be restored forever.
+          key: venv-${{ github.repository }}-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
       
       - name: Install dependencies
         # --all-extras so the audit covers the optional dependencies too. Without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The repository moved to [`sethbang/venice-py`](https://github.com/sethbang/venice-py).**
+  GitHub permanently redirects the old location, so existing links, clones and remotes keep
+  working — no action needed. The project URLs shown on PyPI update with the next release.
+  The import package is still `venice_ai` and `VENICE_API_KEY` is unchanged; this is the last
+  step of the distribution rename, and it changes nothing about what gets built or installed.
+
 ### Fixed
 
 - **`__version__` no longer falls back to a plausible-looking version string.** When the
@@ -126,7 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`messages=` now type-checks with plain dicts.** The parameter was annotated `Sequence[UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage]`, which is narrower than what the code actually accepts: mappings in the OpenAI wire shape (`{"role": "user", "content": "hi"}`) have always been validated and coerced into the corresponding message model, but type checkers rejected them (`error: List item 0 has incompatible type "dict[str, str]"`). The annotation is now the public `ChatMessageParam` union, so both forms check cleanly on `create()`, `stream()`, `parse()`, `estimate_cost()`, and `run_with_tools()`. The typed models remain the documented idiom — they give completion and validation at construction — and malformed mappings still raise `ValidationError` before the request is sent. Reported in [#1](https://github.com/sethbang/venice-ai/issues/1).
+- **`messages=` now type-checks with plain dicts.** The parameter was annotated `Sequence[UserMessage | AssistantMessage | SystemMessage | ToolMessage | DeveloperMessage]`, which is narrower than what the code actually accepts: mappings in the OpenAI wire shape (`{"role": "user", "content": "hi"}`) have always been validated and coerced into the corresponding message model, but type checkers rejected them (`error: List item 0 has incompatible type "dict[str, str]"`). The annotation is now the public `ChatMessageParam` union, so both forms check cleanly on `create()`, `stream()`, `parse()`, `estimate_cost()`, and `run_with_tools()`. The typed models remain the documented idiom — they give completion and validation at construction — and malformed mappings still raise `ValidationError` before the request is sent. Reported in [#1](https://github.com/sethbang/venice-py/issues/1).
 - **`estimate_cost()` and `run_with_tools()` accept mapping messages.** Both read the message list before it reaches the request model, so dict input previously raised `AttributeError` on `.content` (`estimate_cost`) or left raw dicts in the returned `ToolLoopResult.messages` history (`run_with_tools`). Messages are now normalized at the method boundary.
 
 ### Added
@@ -699,18 +707,18 @@ _Initial public release. No retroactive release notes documented._
 
 **Note**: This changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. For detailed technical information about any changes, please refer to the git commit history or the linked source files.
 
-[Unreleased]: https://github.com/sethbang/venice-ai/compare/v2.2.0...HEAD
-[2.2.0]: https://github.com/sethbang/venice-ai/compare/v2.1.0...v2.2.0
-[2.1.0]: https://github.com/sethbang/venice-ai/compare/v2.0.2...v2.1.0
-[2.0.2]: https://github.com/sethbang/venice-ai/compare/v2.0.1...v2.0.2
-[2.0.1]: https://github.com/sethbang/venice-ai/compare/v2.0.0...v2.0.1
-[2.0.0]: https://github.com/sethbang/venice-ai/compare/v1.3.0...v2.0.0
-[1.3.0]: https://github.com/sethbang/venice-ai/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/sethbang/venice-ai/compare/v1.1.2...v1.2.0
-[1.1.2]: https://github.com/sethbang/venice-ai/compare/v1.1.1...v1.1.2
-[1.1.1]: https://github.com/sethbang/venice-ai/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/sethbang/venice-ai/compare/v1.0.3...v1.1.0
-[1.0.3]: https://github.com/sethbang/venice-ai/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/sethbang/venice-ai/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/sethbang/venice-ai/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/sethbang/venice-ai/releases/tag/v1.0.0
+[Unreleased]: https://github.com/sethbang/venice-py/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/sethbang/venice-py/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/sethbang/venice-py/compare/v2.0.2...v2.1.0
+[2.0.2]: https://github.com/sethbang/venice-py/compare/v2.0.1...v2.0.2
+[2.0.1]: https://github.com/sethbang/venice-py/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/sethbang/venice-py/compare/v1.3.0...v2.0.0
+[1.3.0]: https://github.com/sethbang/venice-py/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/sethbang/venice-py/compare/v1.1.2...v1.2.0
+[1.1.2]: https://github.com/sethbang/venice-py/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/sethbang/venice-py/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/sethbang/venice-py/compare/v1.0.3...v1.1.0
+[1.0.3]: https://github.com/sethbang/venice-py/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/sethbang/venice-py/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/sethbang/venice-py/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/sethbang/venice-py/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Thank you for your interest in contributing to the Venice AI Python Client!
 
 If you encounter a bug or have an issue with the library:
 
-1. **Search Existing Issues:** Before submitting a new issue, please check if a similar one has already been reported by searching on GitHub under [Issues](https://github.com/sethbang/venice-ai/issues).
-2. **Open a New Issue:** If you can't find an existing issue that addresses your problem, please [open a new one](https://github.com/sethbang/venice-ai/issues/new).
+1. **Search Existing Issues:** Before submitting a new issue, please check if a similar one has already been reported by searching on GitHub under [Issues](https://github.com/sethbang/venice-py/issues).
+2. **Open a New Issue:** If you can't find an existing issue that addresses your problem, please [open a new one](https://github.com/sethbang/venice-py/issues/new).
    - Provide a **clear and descriptive title**.
    - Include a **detailed description** of the issue.
    - If applicable, provide a **code sample or an executable test case** that demonstrates the problem.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 <div align="center">
 
-<a href="https://venice-docs.sbang.dev/"><img src="https://raw.githubusercontent.com/sethbang/venice-ai/main/website/static/img/venice-py-banner.png" alt="venice-py — unofficial, community-maintained Python SDK for Venice.ai" width="720"></a>
+<a href="https://venice-docs.sbang.dev/"><img src="https://raw.githubusercontent.com/sethbang/venice-py/main/website/static/img/venice-py-banner.png" alt="venice-py — unofficial, community-maintained Python SDK for Venice.ai" width="720"></a>
 
 [![PyPI version](https://img.shields.io/pypi/v/venice-py.svg)](https://pypi.org/project/venice-py/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/venice-py.svg)](https://pypi.org/project/venice-py/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-125da3.svg)](https://opensource.org/licenses/MIT)
-[![CI Status](https://github.com/sethbang/venice-ai/actions/workflows/ci-validation.yaml/badge.svg)](https://github.com/sethbang/venice-ai/actions/workflows/ci-validation.yaml)
-[![Coverage Status](https://img.shields.io/codecov/c/github/sethbang/venice-ai.svg)](https://codecov.io/gh/sethbang/venice-ai)
-[![Security Scan](https://github.com/sethbang/venice-ai/actions/workflows/security-scan.yml/badge.svg)](https://github.com/sethbang/venice-ai/actions/workflows/security-scan.yml)
+[![CI Status](https://github.com/sethbang/venice-py/actions/workflows/ci-validation.yaml/badge.svg)](https://github.com/sethbang/venice-py/actions/workflows/ci-validation.yaml)
+[![Coverage Status](https://img.shields.io/codecov/c/github/sethbang/venice-py.svg)](https://codecov.io/gh/sethbang/venice-py)
+[![Security Scan](https://github.com/sethbang/venice-py/actions/workflows/security-scan.yml/badge.svg)](https://github.com/sethbang/venice-py/actions/workflows/security-scan.yml)
 [![Docs](https://img.shields.io/badge/docs-venice--docs.sbang.dev-3c8fdd)](https://venice-docs.sbang.dev/)
 
 **Production-ready Python SDK for Venice.ai with enterprise-grade rate limiting, intelligent scheduling, and comprehensive error handling**
 
-[Documentation](https://venice-docs.sbang.dev/) | [Examples](https://github.com/sethbang/venice-ai/tree/main/examples/) | [Changelog](https://github.com/sethbang/venice-ai/blob/main/CHANGELOG.md) | [API Reference](https://venice-docs.sbang.dev/docs/api-reference/)
+[Documentation](https://venice-docs.sbang.dev/) | [Examples](https://github.com/sethbang/venice-py/tree/main/examples/) | [Changelog](https://github.com/sethbang/venice-py/blob/main/CHANGELOG.md) | [API Reference](https://venice-docs.sbang.dev/docs/api-reference/)
 
 </div>
 
@@ -23,7 +23,7 @@
 > **This is an unofficial, community-maintained SDK for Venice.ai.**
 > Not affiliated with or endorsed by Venice AI. For official resources visit [Venice.ai](https://venice.ai/).
 
-> **v2.x** — fully breaking rewrite over v1.3.x with enterprise-grade features. Review the [release notes](https://github.com/sethbang/venice-ai/releases), the [CHANGELOG](https://github.com/sethbang/venice-ai/blob/main/CHANGELOG.md), and the [Migration Guide](https://venice-docs.sbang.dev/docs/guides/migration/) before upgrading.
+> **v2.x** — fully breaking rewrite over v1.3.x with enterprise-grade features. Review the [release notes](https://github.com/sethbang/venice-py/releases), the [CHANGELOG](https://github.com/sethbang/venice-py/blob/main/CHANGELOG.md), and the [Migration Guide](https://venice-docs.sbang.dev/docs/guides/migration/) before upgrading.
 
 ---
 
@@ -88,7 +88,7 @@ venice-py skills install --global   # → ~/.claude/skills/
 venice-py skills list               # show bundled skills + install state
 ```
 
-Catalog: `venice-py` (chat / streaming / tools / structured output), `venice-py-multimodal` (image / audio / video / music), `venice-py-production` (retries / rate limits / cost tracking / observability), `venice-py-x402` (wallet auth / SIWE / on-chain top-up). See [`tools/skills/README.md`](https://github.com/sethbang/venice-ai/blob/main/tools/skills/README.md) for the full catalog and validation tooling.
+Catalog: `venice-py` (chat / streaming / tools / structured output), `venice-py-multimodal` (image / audio / video / music), `venice-py-production` (retries / rate limits / cost tracking / observability), `venice-py-x402` (wallet auth / SIWE / on-chain top-up). See [`tools/skills/README.md`](https://github.com/sethbang/venice-py/blob/main/tools/skills/README.md) for the full catalog and validation tooling.
 
 ---
 
@@ -113,7 +113,7 @@ async with VeniceClient() as client:
     print(response.choices[0].message.content)
 ```
 
-[-> `examples/chat/simple_chat.py`](https://github.com/sethbang/venice-ai/blob/main/examples/chat/simple_chat.py)
+[-> `examples/chat/simple_chat.py`](https://github.com/sethbang/venice-py/blob/main/examples/chat/simple_chat.py)
 
 ### Streaming
 
@@ -130,7 +130,7 @@ async with await client.chat.completions.stream(
 
 For the assembled response: `response = await stream.collect()`.
 
-[-> `examples/chat/streaming_chat.py`](https://github.com/sethbang/venice-ai/blob/main/examples/chat/streaming_chat.py)
+[-> `examples/chat/streaming_chat.py`](https://github.com/sethbang/venice-py/blob/main/examples/chat/streaming_chat.py)
 
 ### Synchronous Usage
 
@@ -168,7 +168,7 @@ response = await client.chat.completions.create(
 
 `tool_from_model(MyPydanticModel)` is also available for richer schemas.
 
-[-> `examples/chat/tool_calling.py`](https://github.com/sethbang/venice-ai/blob/main/examples/chat/tool_calling.py)
+[-> `examples/chat/tool_calling.py`](https://github.com/sethbang/venice-py/blob/main/examples/chat/tool_calling.py)
 
 ### Image Generation
 
@@ -187,7 +187,7 @@ response.save("generated.png")          # single image
 Pass-through fields on `image.multi_edit()` now include `model=...`, which the
 SDK forwards to the API as `modelId` (previously dropped silently).
 
-[-> `examples/image/text_to_image.py`](https://github.com/sethbang/venice-ai/blob/main/examples/image/text_to_image.py) | [-> `examples/image/web_search.py`](https://github.com/sethbang/venice-ai/blob/main/examples/image/web_search.py)
+[-> `examples/image/text_to_image.py`](https://github.com/sethbang/venice-py/blob/main/examples/image/text_to_image.py) | [-> `examples/image/web_search.py`](https://github.com/sethbang/venice-py/blob/main/examples/image/web_search.py)
 
 ### Text-to-Speech
 
@@ -204,7 +204,7 @@ response = await client.audio.create_speech(
 response.save("speech.mp3")
 ```
 
-[-> `examples/audio/text_to_speech.py`](https://github.com/sethbang/venice-ai/blob/main/examples/audio/text_to_speech.py)
+[-> `examples/audio/text_to_speech.py`](https://github.com/sethbang/venice-py/blob/main/examples/audio/text_to_speech.py)
 
 ### Embeddings
 
@@ -217,7 +217,7 @@ response = await client.embeddings.create(
 embedding = response.data[0].embedding
 ```
 
-[-> `examples/embeddings/basic_embeddings.py`](https://github.com/sethbang/venice-ai/blob/main/examples/embeddings/basic_embeddings.py)
+[-> `examples/embeddings/basic_embeddings.py`](https://github.com/sethbang/venice-py/blob/main/examples/embeddings/basic_embeddings.py)
 
 ### Video Generation
 
@@ -245,7 +245,7 @@ subset (`model`, `duration_seconds`, `aspect_ratio`, `resolution`, `upscale_fact
 `audio`, `video_url`) per the API spec — prompt text and reference images
 don't affect price.
 
-[-> `examples/video/text_to_video.py`](https://github.com/sethbang/venice-ai/blob/main/examples/video/text_to_video.py) | [-> `examples/video/advanced_fields.py`](https://github.com/sethbang/venice-ai/blob/main/examples/video/advanced_fields.py) | [-> `examples/video/upscale.py`](https://github.com/sethbang/venice-ai/blob/main/examples/video/upscale.py)
+[-> `examples/video/text_to_video.py`](https://github.com/sethbang/venice-py/blob/main/examples/video/text_to_video.py) | [-> `examples/video/advanced_fields.py`](https://github.com/sethbang/venice-py/blob/main/examples/video/advanced_fields.py) | [-> `examples/video/upscale.py`](https://github.com/sethbang/venice-py/blob/main/examples/video/upscale.py)
 
 ### Model Selection
 
@@ -306,7 +306,7 @@ parsed = await client.augment.parse_text(file="report.pdf")
 print(parsed.text, parsed.tokens)
 ```
 
-[-> `examples/augment/scrape.py`](https://github.com/sethbang/venice-ai/blob/main/examples/augment/scrape.py) | [-> `examples/augment/search.py`](https://github.com/sethbang/venice-ai/blob/main/examples/augment/search.py) | [-> `examples/augment/text_parser.py`](https://github.com/sethbang/venice-ai/blob/main/examples/augment/text_parser.py)
+[-> `examples/augment/scrape.py`](https://github.com/sethbang/venice-py/blob/main/examples/augment/scrape.py) | [-> `examples/augment/search.py`](https://github.com/sethbang/venice-py/blob/main/examples/augment/search.py) | [-> `examples/augment/text_parser.py`](https://github.com/sethbang/venice-py/blob/main/examples/augment/text_parser.py)
 
 ### x402 Wallet Billing (optional)
 
@@ -348,7 +348,7 @@ async with VeniceClient() as client:
     await client.x402.top_up_with_solana(auth=auth, amount_usdc=5.0)
 ```
 
-[-> `examples/x402/balance.py`](https://github.com/sethbang/venice-ai/blob/main/examples/x402/balance.py) | [-> `examples/x402/transactions.py`](https://github.com/sethbang/venice-ai/blob/main/examples/x402/transactions.py) | [-> `examples/x402/top_up.py`](https://github.com/sethbang/venice-ai/blob/main/examples/x402/top_up.py)
+[-> `examples/x402/balance.py`](https://github.com/sethbang/venice-py/blob/main/examples/x402/balance.py) | [-> `examples/x402/transactions.py`](https://github.com/sethbang/venice-py/blob/main/examples/x402/transactions.py) | [-> `examples/x402/top_up.py`](https://github.com/sethbang/venice-py/blob/main/examples/x402/top_up.py)
 
 ### Confidential Compute (TEE / E2EE, optional)
 
@@ -519,20 +519,20 @@ Rate limiting, distributed state, monitoring, observability, and performance tun
 
 | Resource | Purpose | Key Methods | Example |
 |----------|---------|-------------|---------|
-| `chat.completions` | Chat & text generation | `create()` | [simple_chat.py](https://github.com/sethbang/venice-ai/blob/main/examples/chat/simple_chat.py) |
+| `chat.completions` | Chat & text generation | `create()` | [simple_chat.py](https://github.com/sethbang/venice-py/blob/main/examples/chat/simple_chat.py) |
 | `responses` | Stateless multi-modal generation (Alpha) | `create()` | — |
-| `image` | Image generation | `create()`, `background_remove()` | [text_to_image.py](https://github.com/sethbang/venice-ai/blob/main/examples/image/text_to_image.py) |
-| `video` | Async video generation | `run()` → `VideoJob`, low-level `submit()` / `quote()` / `retrieve()` / `cancel()` | [text_to_video.py](https://github.com/sethbang/venice-ai/blob/main/examples/video/text_to_video.py) |
-| `audio` | TTS / ASR | `create_speech()`, `transcribe()` | [text_to_speech.py](https://github.com/sethbang/venice-ai/blob/main/examples/audio/text_to_speech.py) |
-| `music` | Async music generation | `run()` → `MusicJob`, low-level `submit()` / `quote()` / `retrieve()` / `cancel()` | [music_generation.py](https://github.com/sethbang/venice-ai/blob/main/examples/music/music_generation.py) |
-| `embeddings` | Text embeddings | `create()` | [basic_embeddings.py](https://github.com/sethbang/venice-ai/blob/main/examples/embeddings/basic_embeddings.py) |
-| `models` | Model discovery | `list()`, `get()` | [list_models.py](https://github.com/sethbang/venice-ai/blob/main/examples/models/list_models.py) |
-| `billing` | Usage analytics | `get_balance()`, `get_usage_history()`, `get_usage_analytics()` | [usage_analytics.py](https://github.com/sethbang/venice-ai/blob/main/examples/billing/usage_analytics.py) |
-| `api_keys` | Key management | `list()`, `get_rate_limits()` | [key_management.py](https://github.com/sethbang/venice-ai/blob/main/examples/api_keys/key_management.py) |
-| `characters` | Character discovery & reviews | `list()`, `get()`, `reviews()` | [character_details.py](https://github.com/sethbang/venice-ai/blob/main/examples/characters/character_details.py) |
-| `augment` | Web scrape / search / text-parser | `scrape()`, `search()`, `parse_text()` | [scrape.py](https://github.com/sethbang/venice-ai/blob/main/examples/augment/scrape.py) |
-| `x402` | Wallet-billing (SIWE auth; `[x402]` extra) | `balance()`, `transactions()`, `top_up()` | [balance.py](https://github.com/sethbang/venice-ai/blob/main/examples/x402/balance.py) |
-| `crypto` | Multi-chain JSON-RPC proxy | `networks()`, `rpc()`, `batch_rpc()` | [networks_and_rpc.py](https://github.com/sethbang/venice-ai/blob/main/examples/crypto/networks_and_rpc.py) |
+| `image` | Image generation | `create()`, `background_remove()` | [text_to_image.py](https://github.com/sethbang/venice-py/blob/main/examples/image/text_to_image.py) |
+| `video` | Async video generation | `run()` → `VideoJob`, low-level `submit()` / `quote()` / `retrieve()` / `cancel()` | [text_to_video.py](https://github.com/sethbang/venice-py/blob/main/examples/video/text_to_video.py) |
+| `audio` | TTS / ASR | `create_speech()`, `transcribe()` | [text_to_speech.py](https://github.com/sethbang/venice-py/blob/main/examples/audio/text_to_speech.py) |
+| `music` | Async music generation | `run()` → `MusicJob`, low-level `submit()` / `quote()` / `retrieve()` / `cancel()` | [music_generation.py](https://github.com/sethbang/venice-py/blob/main/examples/music/music_generation.py) |
+| `embeddings` | Text embeddings | `create()` | [basic_embeddings.py](https://github.com/sethbang/venice-py/blob/main/examples/embeddings/basic_embeddings.py) |
+| `models` | Model discovery | `list()`, `get()` | [list_models.py](https://github.com/sethbang/venice-py/blob/main/examples/models/list_models.py) |
+| `billing` | Usage analytics | `get_balance()`, `get_usage_history()`, `get_usage_analytics()` | [usage_analytics.py](https://github.com/sethbang/venice-py/blob/main/examples/billing/usage_analytics.py) |
+| `api_keys` | Key management | `list()`, `get_rate_limits()` | [key_management.py](https://github.com/sethbang/venice-py/blob/main/examples/api_keys/key_management.py) |
+| `characters` | Character discovery & reviews | `list()`, `get()`, `reviews()` | [character_details.py](https://github.com/sethbang/venice-py/blob/main/examples/characters/character_details.py) |
+| `augment` | Web scrape / search / text-parser | `scrape()`, `search()`, `parse_text()` | [scrape.py](https://github.com/sethbang/venice-py/blob/main/examples/augment/scrape.py) |
+| `x402` | Wallet-billing (SIWE auth; `[x402]` extra) | `balance()`, `transactions()`, `top_up()` | [balance.py](https://github.com/sethbang/venice-py/blob/main/examples/x402/balance.py) |
+| `crypto` | Multi-chain JSON-RPC proxy | `networks()`, `rpc()`, `batch_rpc()` | [networks_and_rpc.py](https://github.com/sethbang/venice-py/blob/main/examples/crypto/networks_and_rpc.py) |
 | `tee` | Confidential-compute attestation & E2EE session (`[e2ee]` extra) | `get_attestation()`, `open_session()` | — |
 
 ## Type Safety
@@ -587,7 +587,7 @@ See [Installation Options](#installation-options) for optional dependencies.
 ## Contributing
 
 ```bash
-git clone https://github.com/sethbang/venice-ai.git && cd venice-ai
+git clone https://github.com/sethbang/venice-py.git && cd venice-py
 poetry install
 make test
 ```
@@ -597,13 +597,13 @@ Follow PEP 8, use type hints, write tests, and submit a PR.
 ## Support
 
 - [Documentation](https://venice-docs.sbang.dev/)
-- [Issue Tracker](https://github.com/sethbang/venice-ai/issues)
-- [Examples](https://github.com/sethbang/venice-ai/tree/main/examples/)
-- [Changelog](https://github.com/sethbang/venice-ai/blob/main/CHANGELOG.md)
+- [Issue Tracker](https://github.com/sethbang/venice-py/issues)
+- [Examples](https://github.com/sethbang/venice-py/tree/main/examples/)
+- [Changelog](https://github.com/sethbang/venice-py/blob/main/CHANGELOG.md)
 
 ## License
 
-MIT License — see [`LICENSE`](https://github.com/sethbang/venice-ai/blob/main/LICENSE).
+MIT License — see [`LICENSE`](https://github.com/sethbang/venice-py/blob/main/LICENSE).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,11 +133,11 @@ all = [
 ]
 
 [tool.poetry.urls]
-Homepage = "https://github.com/sethbang/venice-ai"
-Repository = "https://github.com/sethbang/venice-ai"
+Homepage = "https://github.com/sethbang/venice-py"
+Repository = "https://github.com/sethbang/venice-py"
 Documentation = "https://venice-docs.sbang.dev"
-"Issue Tracker" = "https://github.com/sethbang/venice-ai/issues"
-"Changelog" = "https://github.com/sethbang/venice-ai/blob/main/CHANGELOG.md"
+"Issue Tracker" = "https://github.com/sethbang/venice-py/issues"
+"Changelog" = "https://github.com/sethbang/venice-py/blob/main/CHANGELOG.md"
 
 [tool.poetry.group.dev.dependencies]
 adaptive-rate-limiter = "^1.1.0"

--- a/src/venice_ai/skills/venice-py/SKILL.md
+++ b/src/venice_ai/skills/venice-py/SKILL.md
@@ -345,7 +345,7 @@ To catch these patterns automatically in user code, run **`venice-py lint <path>
 
 ## Examples to read
 
-Paths below are relative to the SDK repo's `examples/` directory. Available at [github.com/sethbang/venice-ai/tree/main/examples](https://github.com/sethbang/venice-ai/tree/main/examples) or in your local clone of the SDK.
+Paths below are relative to the SDK repo's `examples/` directory. Available at [github.com/sethbang/venice-py/tree/main/examples](https://github.com/sethbang/venice-py/tree/main/examples) or in your local clone of the SDK.
 
 - `basic/quick_start.py` — minimal client setup
 - `chat/simple_chat.py` — non-streaming chat

--- a/website/docs/guides/advanced.md
+++ b/website/docs/guides/advanced.md
@@ -109,7 +109,7 @@ async def make_request_with_retry(client, max_retries=3):
             raise
 ```
 
-[**-> Full example: `examples/basic/error_handling.py`**](https://github.com/sethbang/venice-ai/blob/main/examples/basic/error_handling.py)
+[**-> Full example: `examples/basic/error_handling.py`**](https://github.com/sethbang/venice-py/blob/main/examples/basic/error_handling.py)
 
 ## Distributed State Management
 
@@ -210,7 +210,7 @@ if response.balance_info:
     print(f"Balance: {response.balance_info.usd} USD")
 ```
 
-[**-> Full example: `examples/headers/header_access_example.py`**](https://github.com/sethbang/venice-ai/blob/main/examples/headers/header_access_example.py)
+[**-> Full example: `examples/headers/header_access_example.py`**](https://github.com/sethbang/venice-py/blob/main/examples/headers/header_access_example.py)
 
 ## Performance & Optimization
 

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -41,8 +41,8 @@ poetry add 'venice-py[cli]'
 ### Development Install
 
 ```bash
-git clone https://github.com/sethbang/venice-ai.git
-cd venice-ai
+git clone https://github.com/sethbang/venice-py.git
+cd venice-py
 poetry install --all-extras
 poetry run venice-py --version
 ```
@@ -1451,6 +1451,6 @@ Run `venice-py models` to see available models. Use `venice-py models --type tex
 
 - [Venice AI Documentation](https://docs.venice.ai)
 - [API Reference](https://docs.venice.ai/api)
-- [Main SDK README](https://github.com/sethbang/venice-ai/blob/main/README.md)
-- [Examples](https://github.com/sethbang/venice-ai/blob/main/examples/)
-- [Changelog](https://github.com/sethbang/venice-ai/blob/main/CHANGELOG.md)
+- [Main SDK README](https://github.com/sethbang/venice-py/blob/main/README.md)
+- [Examples](https://github.com/sethbang/venice-py/blob/main/examples/)
+- [Changelog](https://github.com/sethbang/venice-py/blob/main/CHANGELOG.md)

--- a/website/docs/guides/migration.md
+++ b/website/docs/guides/migration.md
@@ -6,7 +6,7 @@ crypto, augment, x402, a CLI, rate limiting, and more) ships alongside the v1 su
 
 This guide covers everything a **v1.3.x** user must change to move to v2.0.0, in
 rough order of impact. For the complete list of additions, see the
-[CHANGELOG](https://github.com/sethbang/venice-ai/blob/main/CHANGELOG.md).
+[CHANGELOG](https://github.com/sethbang/venice-py/blob/main/CHANGELOG.md).
 
 ---
 
@@ -379,7 +379,7 @@ attested enclave key, stream the response, and decrypt it locally.
   does **not** perform full client-side Intel TDX + NVIDIA quote verification. A
   one-time `UserWarning` is emitted on engagement. Supply a `FullQuoteVerifier`
   via `e2ee=TeeOptions(verifier=...)` if your threat model requires it. See
-  [CHANGELOG § TEE client-side end-to-end encryption](https://github.com/sethbang/venice-ai/blob/main/CHANGELOG.md).
+  [CHANGELOG § TEE client-side end-to-end encryption](https://github.com/sethbang/venice-py/blob/main/CHANGELOG.md).
 
 ### New kwargs on existing methods
 
@@ -392,5 +392,5 @@ attested enclave key, stream the response, and decrypt it locally.
 
 ## Further Reading
 
-- [CHANGELOG](https://github.com/sethbang/venice-ai/blob/main/CHANGELOG.md) — complete list of all changes in v2.0.0
-- [README](https://github.com/sethbang/venice-ai/blob/main/README.md) — updated usage examples for v2
+- [CHANGELOG](https://github.com/sethbang/venice-py/blob/main/CHANGELOG.md) — complete list of all changes in v2.0.0
+- [README](https://github.com/sethbang/venice-py/blob/main/README.md) — updated usage examples for v2

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -11,7 +11,7 @@ const config: Config = {
   baseUrl: '/',
 
   organizationName: 'sethbang',
-  projectName: 'venice-ai',
+  projectName: 'venice-py',
 
   onBrokenLinks: 'throw',
 
@@ -32,7 +32,7 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.ts',
-          editUrl: 'https://github.com/sethbang/venice-ai/tree/main/website/',
+          editUrl: 'https://github.com/sethbang/venice-py/tree/main/website/',
         },
         blog: false,
         theme: {
@@ -72,7 +72,7 @@ const config: Config = {
       items: [
         {type: 'docSidebar', sidebarId: 'guidesSidebar', position: 'left', label: 'Docs'},
         {type: 'docSidebar', sidebarId: 'apiSidebar', position: 'left', label: 'API Reference'},
-        {href: 'https://github.com/sethbang/venice-ai', label: 'GitHub', position: 'right'},
+        {href: 'https://github.com/sethbang/venice-py', label: 'GitHub', position: 'right'},
       ],
     },
     footer: {


### PR DESCRIPTION
Phase 5 — the last step of the `venice-ai` → `venice-py` rename. The repo is now **[sethbang/venice-py](https://github.com/sethbang/venice-py)**; this lands the URLs.

### Why the rename came first

GitHub redirects **old → new, never new → old**. So `sethbang/venice-ai` URLs kept working right up to this commit, while `sethbang/venice-py` URLs would have 404'd before it. Renaming first meant nothing was broken in between; sweeping first would have.

### What changed

69 references across 10 files, plus:

- `docusaurus.config.ts` — `projectName` and `editUrl`
- the two `git clone … && cd` instructions
- the README banner (`raw.githubusercontent.com`) and the codecov badge
- `pyproject.toml` Homepage / Repository / Issue Tracker / Changelog — these are what PyPI displays, and they update with the next release
- `publish-testpypi.yaml`'s header comment recording the registered repo name

### Why a lookahead, not a substitution

```
sethbang/venice-ai(?![-\w])
```

`sethbang/venice-ai` is a **prefix of three sibling repos** under this owner — `venice-ai-rc`, `venice-ai-priv`, `venice-ai-streamlit-demo`. A plain `sed` rewrites the archive guard in `ci-validation.yaml`:

```yaml
if: github.repository != 'sethbang/venice-ai-rc'      # correct
if: github.repository != 'sethbang/venice-py-rc'      # what a naive sweep produces
```

That fails **silently** — the codecov upload just starts running on the private archive. Guarding only `-rc` wouldn't have been enough either; the character class covers the whole family. Verified unchanged.

### What deliberately still says `venice-ai`

Because that is what it means, not because it was missed. All counted before and after the sweep:

| | count |
|---|---|
| `sethbang/venice-ai-rc` (archive guard) | 1 |
| `@venice-ai/x402-client` (npm, different registry) | 3 |
| `venice-ai-redis-node-*` (docker containers) | 5 |
| `venice-ai-docs` (live Cloudflare Pages project) | 2 |
| legacy skill dir names (`venice-ai-multimodal` / `-production` / `-x402`) | 16 |
| `pip install venice-ai` (the old distribution name) | 11 |
| `venice-ai<2` (v1 exists only under the old name) | 4 |
| `venice-ai-test` (a User-Agent literal in a VCR test) | 2 |

Verification is tracked-files-only, matching what the sweep rewrites — untracked local files legitimately still say `venice-ai` and aren't its business.

### Publishing is unaffected

Both publish workflows already guard on `github.repository_owner == 'sethbang'`, so neither silently skips under the new name. A second Trusted Publisher for `sethbang/venice-py` was registered on **both** PyPI and TestPyPI *before* the rename, with the existing entries left live — those get removed only after a TestPyPI rc dispatch proves the chain.

### Verification

`make format-check`, pyright, and the Docusaurus build under `onBrokenLinks: 'throw'` (82 documents) all clean. The sweep's own verifier compares before/after counts for every non-target and exits 1 on any drift — exercised on both paths, including deliberately removing the lookahead to confirm it catches the corrupted guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)