### PR TITLE
docs: explain the venice-py name up front, and how to register the publishers

### DIFF
--- a/.github/workflows/publish-testpypi.yaml
+++ b/.github/workflows/publish-testpypi.yaml
@@ -5,16 +5,29 @@
 # any version that is not an rc/a/b pre-release, so it can never shadow a
 # real release.
 #
-# Trusted Publisher setup (one-time, on test.pypi.org):
-#   1. Log into https://test.pypi.org/manage/account/publishing/
-#   2. Add a new pending publisher with:
-#        - PyPI Project Name:    venice-py
+# Trusted Publisher setup (on test.pypi.org). The project now exists, so register
+# from the **venice-py project's own** Publishing tab —
+# https://test.pypi.org/manage/project/venice-py/settings/publishing/ :
+#
 #        - Owner:                sethbang
-#        - Repository name:      venice-py   (update if the repo is ever renamed)
-#        - Workflow name:        publish-testpypi.yaml
+#        - Repository name:      venice-py
+#        - Workflow name:        publish-testpypi.yaml   <- .yaml, NOT .yml
 #        - Environment name:     testpypi
-#   3. Save. A pending publisher becomes a real one on the first
-#      successful publish from this workflow.
+#
+# The account-level pending-publisher form at /manage/account/publishing/ is NOT
+# the right place any more. A pending publisher only authorizes *creating* a
+# project that does not exist; against an existing project it cannot authorize an
+# upload.
+#
+# Two ways this goes wrong quietly:
+#
+#   1. Registered under the wrong project — venice-ai rather than venice-py. PyPI
+#      still mints a token, because the claims match, and the upload then fails
+#      with "403 Invalid API Token: OIDC scoped token is not valid for project
+#      'venice-py'". This happened on 2026-08-21. A publisher matching nothing
+#      fails earlier and looks different: a trusted-publishing *exchange* error.
+#   2. Recorded as publish-testpypi.yml. This repo uses both extensions, so the
+#      wrong one is easy to type and simply never matches.
 #
 # Why a separate environment from `pypi`:
 #   - Lets the GitHub repo restrict who can manually trigger TestPyPI

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,32 @@
 # reliably, and pypa/gh-action-pypi-publish stays on @release/v1 because that branch tracks
 # the latest release-v1.x patch — pinning it to a commit SHA would break
 # Trusted Publishing's audit trail.
+#
+# Trusted Publisher setup (on pypi.org). Register it from the **venice-py project's
+# own** Publishing tab — https://pypi.org/manage/project/venice-py/settings/publishing/
+# — not from the account-level pending-publisher form and not from another project:
+#
+#        - PyPI Project Name:    venice-py
+#        - Owner:                sethbang
+#        - Repository name:      venice-py
+#        - Workflow name:        release.yaml      <- .yaml, NOT .yml
+#        - Environment name:     pypi
+#
+# Two ways this goes wrong quietly:
+#
+#   1. Registered under the wrong project. PyPI still mints a token, because the
+#      claims match — it is just scoped elsewhere — and the upload fails with
+#      "403 Invalid API Token: OIDC scoped token is not valid for project
+#      'venice-py'". A publisher that matches nothing fails earlier and looks
+#      different: a trusted-publishing *exchange* error, not a 403.
+#   2. Recorded as release.yml. This repo uses both extensions (.yaml here and in
+#      publish-testpypi.yaml, .yml for docs/e2e/security-scan/skills/examples), so
+#      the wrong one is easy to type and simply never matches.
+#
+# A publisher is only proven by a successful upload, never by its config page, and
+# PyPI versions are not reusable — so exercise changes through
+# publish-testpypi.yaml first. TestPyPI and PyPI are configured separately; a
+# mistake on one is likely repeated on the other.
 
 name: Publish to PyPI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The README now carries a short note explaining that the package installs as `venice-py`,
+  that imports and `VENICE_API_KEY` are unchanged, and that the `venice-ai` bridge declares
+  no extras — so `venice-ai[cli]` and friends need the name updated.
+
 - **The repository moved to [`sethbang/venice-py`](https://github.com/sethbang/venice-py).**
   GitHub permanently redirects the old location, so existing links, clones and remotes keep
   working — no action needed. The project URLs shown on PyPI update with the next release.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@
 > **This is an unofficial, community-maintained SDK for Venice.ai.**
 > Not affiliated with or endorsed by Venice AI. For official resources visit [Venice.ai](https://venice.ai/).
 
+> **Installed as `venice-py`.** This package was published as `venice-ai` through v2.1.0.
+> **Your code does not change** — the import package is still `venice_ai` and the environment
+> variable is still `VENICE_API_KEY`. Only the name you install moved:
+>
+> ```bash
+> pip install venice-py     # was: pip install venice-ai
+> ```
+>
+> `venice-ai` stays on PyPI and nothing is yanked, so existing pins keep resolving. Its final
+> release, 2.1.1, is a metadata-only bridge that pulls in `venice-py`. The bridge declares **no
+> extras**, so if you install any — `[cli]`, `[x402]`, `[redis]`, `[all]` — switch the name or
+> pip will warn and quietly skip them.
+
 > **v2.x** — fully breaking rewrite over v1.3.x with enterprise-grade features. Review the [release notes](https://github.com/sethbang/venice-py/releases), the [CHANGELOG](https://github.com/sethbang/venice-py/blob/main/CHANGELOG.md), and the [Migration Guide](https://venice-docs.sbang.dev/docs/guides/migration/) before upgrading.
 
 ---


### PR DESCRIPTION
Three documentation gaps, each of which cost real time this week.

### README had nothing about the rename

Someone arriving from a `venice-ai` link or an old bookmark had no indication the package installs under a new name — it was only in the CHANGELOG and the migration guide. The new note sits with the existing callouts and says what changed (the install name), what didn't (imports, `VENICE_API_KEY`), and the one thing that is **not** transparent:

> the 2.1.1 bridge declares **no extras**, so `venice-ai[cli]` resolves with a warning and silently installs nothing extra

Verified:

```
$ pip install "venice-ai[x402] >= 2.0.1, < 3"
WARNING: venice-ai 2.1.1 does not provide the extra 'x402'
  → venice-ai 2.1.1, venice-py 2.2.0   (and zero x402 packages)

$ pip install "venice-py[x402]"
  → 8 x402 packages
```

### `publish-testpypi.yaml` gave instructions that are now wrong

Its header told the reader to register from the **account-level pending-publisher form**. That was correct when the project didn't exist and is wrong now: a pending publisher only authorizes *creating* a project, so against an existing one it cannot authorize an upload. Following it is one of the two ways to produce the 403 we hit.

Now points at the project's own Publishing tab, and documents both failure modes.

### `release.yaml` documented its publisher not at all

Despite being the higher-stakes of the two — PyPI versions are never reusable, so a misconfiguration there is discovered *during a real release*. It now carries the same block as its TestPyPI sibling.

### The failure mode both headers now spell out

A publisher registered under the **wrong project** still mints a token, because the claims match — it's just scoped elsewhere:

```
INFO  username: __token__
INFO  password: <hidden>          ← a token WAS minted
403 Invalid API Token: OIDC scoped token is not valid for project 'venice-py'
```

A publisher that matches *nothing* fails earlier and looks different: a trusted-publishing *exchange* error, not a 403 from the upload endpoint. Reading those two apart is the whole diagnosis.

Both headers also flag that the workflow name must be recorded with the right extension — this repo uses `.yaml` for `release.yaml` / `publish-testpypi.yaml` and `.yml` for the other five, and a publisher recorded with the wrong one silently never matches.

Docs only — no code, no workflow logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)